### PR TITLE
Users can disconnect their iCIMS account

### DIFF
--- a/app/controllers/icims_connections_controller.rb
+++ b/app/controllers/icims_connections_controller.rb
@@ -12,6 +12,11 @@ class IcimsConnectionsController < ApplicationController
     end
   end
 
+  def destroy
+    current_user.icims_connection.disconnect
+    redirect_to dashboard_path
+  end
+
   private
 
   def icims_connection_params

--- a/app/models/icims/connection.rb
+++ b/app/models/icims/connection.rb
@@ -5,5 +5,12 @@ module Icims
     def connected?
       username.present? && password.present?
     end
+
+    def disconnect
+      update(
+        password: nil,
+        username: nil,
+      )
+    end
   end
 end

--- a/app/views/dashboards/_disconnect_button.html.erb
+++ b/app/views/dashboards/_disconnect_button.html.erb
@@ -1,0 +1,4 @@
+<%= button_to path, class: "-n-btn -n-btn-sm -n-btn-danger -n-btn-link", method: :delete, rel: "nofollow" do %>
+  <%= fa_icon "times" %>
+  <%= t("dashboards.show.disconnect") %>
+<% end %>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,4 +1,5 @@
 <%= render "subheader" %>
+
 <section>
   <table>
     <tbody>
@@ -17,10 +18,7 @@
             <%= button_to t("dashboards.show.import_now"), jobvite_imports_path, class: '-n-btn' %>
           </td>
           <td>
-            <%= link_to jobvite_connection_path, class: "-n-btn -n-btn-sm -n-btn-danger -n-btn-link", method: :delete, rel: "nofollow" do %>
-              <%= fa_icon "times" %>
-              <%= t("dashboards.show.disconnect") %>
-            <% end %>
+            <%= render "disconnect_button", path: jobvite_connection_path %>
           </td>
         <% else %>
           <td>
@@ -37,13 +35,24 @@
       </tr>
 
       <tr class="icims-account">
-        <td>
-          <% if !@icims_connection.connected? %>
+        <% if @icims_connection.connected? %>
+          <td>
+            <%= fa_icon "check-circle", class: "connected", text: "iCIMS" %>
+            <p><%= @icims_connection.username %></p>
+          </td>
+          <td>
+            <%= render "disconnect_button", path: icims_connection_path %>
+          </td>
+        <% else %>
+          <td>
+            <%= fa_icon "minus-circle", class: "disconnected", text: "iCIMS" %>
+          </td>
+          <td>
             <%= link_to edit_icims_connection_path, class: "-n-btn -n-btn-sm" do %>
               <%= fa_icon "plug", text: t("dashboards.show.connect") %>
             <% end %>
-          <% end %>
-        </td>
+          </td>
+        <% end %>
       </tr>
     </tbody>
   </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root to: "homepages#show"
   resource :dashboard, only: [:show]
   resource :jobvite_connection, only: [:edit, :update, :destroy]
-  resource :icims_connection, only: [:edit, :update]
+  resource :icims_connection, only: [:edit, :update, :destroy]
   resources :jobvite_imports, only: [:create]
   resource :session, only: [:new, :destroy]
   get "/session/oauth_callback", to: "sessions#oauth_callback", as: "session_oauth_callback"

--- a/spec/features/user_connects_icims_account_spec.rb
+++ b/spec/features/user_connects_icims_account_spec.rb
@@ -15,7 +15,6 @@ feature "User connects iCIMS account" do
     fill_in field("icims_connection.password"), with: "password"
     click_button button("icims_connection.update")
 
-
     within(".icims-account") do
       expect(page).to have_no_link t("dashboards.show.connect")
     end

--- a/spec/features/user_deletes_icims_connection_spec.rb
+++ b/spec/features/user_deletes_icims_connection_spec.rb
@@ -1,26 +1,25 @@
 require "rails_helper"
 
-feature "User deletes Jobvite connection" do
+feature "User deletes iCIMS connection" do
   scenario "successfully" do
     user = create(:user)
     create(
-      :jobvite_connection,
+      :icims_connection,
       :connected,
       user: user,
-      found_namely_field: true,
     )
 
     visit dashboard_path(as: user)
 
-    within(".jobvite-account") do
+    within(".icims-account") do
       expect(page).to have_button t("dashboards.show.disconnect")
     end
 
-    within(".jobvite-account") do
+    within(".icims-account") do
       click_button t("dashboards.show.disconnect")
     end
 
-    within(".jobvite-account") do
+    within(".icims-account") do
       expect(page).not_to have_button t("dashboards.show.disconnect")
       expect(page).to have_link t("dashboards.show.connect")
     end

--- a/spec/models/icims/connection_spec.rb
+++ b/spec/models/icims/connection_spec.rb
@@ -21,4 +21,19 @@ describe Icims::Connection do
       expect(described_class.new(password: "password")).not_to be_connected
     end
   end
+
+  describe "#disconnect" do
+    it "sets the username and password to nil" do
+      icims_connection = create(
+        :icims_connection,
+        username: "crashoverride",
+        password: "riscisgood",
+      )
+
+      icims_connection.disconnect
+
+      expect(icims_connection.username).to be_nil
+      expect(icims_connection.password).to be_nil
+    end
+  end
 end

--- a/spec/models/jobvite/connection_spec.rb
+++ b/spec/models/jobvite/connection_spec.rb
@@ -28,7 +28,7 @@ describe Jobvite::Connection do
       jobvite_connection = create(
         :jobvite_connection,
         api_key: "a",
-        secret: "b"
+        secret: "b",
       )
 
       jobvite_connection.disconnect

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,4 +1,13 @@
 FactoryGirl.define do
+  factory :icims_connection, class: "Icims::Connection" do
+    user
+
+    trait :connected do
+      username "crashoverride"
+      password "riscisgood"
+    end
+  end
+
   factory :jobvite_connection, class: "Jobvite::Connection" do
     user
 


### PR DESCRIPTION
This just deletes their credentials. Jobvite disconnection works the same way.