### PR TITLE
Implement HMAC authentication

### DIFF
--- a/app/models/icims/authorized_request.rb
+++ b/app/models/icims/authorized_request.rb
@@ -1,0 +1,100 @@
+module Icims
+  class AuthorizedRequest < SimpleDelegator
+    alias request __getobj__
+    HMAC_SHA256_HEADER = "x-icims-v1-hmac-sha256"
+
+    def initialize(connection:, request:)
+      super(request)
+      @connection = connection
+    end
+
+    def headers
+      @headers ||= {
+        "content-type" => "application/json",
+        "host" => uri.host,
+        "x-icims-date" => current_time.iso8601,
+        "x-icims-content-sha256" => hashed_payload,
+      }
+    end
+
+    def canonical_request
+      [
+        request.method.upcase,
+        canonical_uri,
+        canonical_query,
+        canonical_headers,
+        "",
+        requested_headers,
+      ].join("\n")
+    end
+
+    def string_to_sign
+      [
+        HMAC_SHA256_HEADER,
+        current_time.iso8601,
+        digest.hexdigest(canonical_request),
+      ].join("\n")
+    end
+
+    def signature
+      OpenSSL::HMAC.hexdigest(digest, connection.key, string_to_sign)
+    end
+
+    def authorization_header
+      [
+        "x-icims-v1-hmac-sha256 user=#{connection.username}",
+        "signedheaders=#{requested_headers}",
+        "signature=#{signature}",
+      ].join(", ")
+    end
+
+    def execute
+      RestClient::Request.new(
+        method: request.method,
+        url: url,
+        headers: headers.merge(
+          "Authorization" => authorization_header,
+        ),
+        data: payload,
+      ).execute
+    end
+
+    private
+
+    attr_reader :connection
+
+    def canonical_headers
+      headers.map do |header, value|
+        [header, value].join(": ")
+      end.sort.join("\n")
+    end
+
+    def requested_headers
+      headers.keys.sort.join(";")
+    end
+
+    def current_time
+      @current_time ||= Time.current
+    end
+
+    def canonical_uri
+      uri.path
+    end
+
+    def canonical_query
+      uri.query
+    end
+
+    def uri
+      URI.parse(url)
+    end
+
+    def digest
+      OpenSSL::Digest::SHA256.new
+    end
+
+    def hashed_payload
+      digest.hexdigest(payload.to_s)
+    end
+  end
+end

--- a/spec/models/icims/authorized_request_spec.rb
+++ b/spec/models/icims/authorized_request_spec.rb
@@ -1,0 +1,129 @@
+require "rails_helper"
+
+describe Icims::AuthorizedRequest do
+  describe "#headers" do
+    it "request has the necessary information" do
+      expect(authorized_request.headers.keys).
+        to match_array [
+          "content-type",
+          "host",
+          "x-icims-content-sha256",
+          "x-icims-date",
+        ]
+    end
+
+    it "sends a header with a hash of its payload" do
+      expect(authorized_request.headers["x-icims-content-sha256"]).
+        to eq OpenSSL::Digest::SHA256.new(post_request.payload).hexdigest
+    end
+
+    it "sends a header with formatted date time of its request" do
+      Timecop.freeze(Time.current) do
+        expect(authorized_request.headers["x-icims-date"]).
+          to eq Time.current.iso8601
+      end
+    end
+  end
+
+  describe "#canonical_request" do
+    it "returns a string of several attributes on the request" do
+      request = RestClient::Request.new(
+        method: :get,
+        url: "https://api.icims.com/or-ya-know?fields=stuff",
+        headers: {},
+      )
+
+      expect(authorized_request(request).canonical_request).
+        to eq canonical_request(request)
+    end
+  end
+
+  describe "#string_to_sign" do
+    it "returns a string to sign" do
+      signable_string = [
+        "x-icims-v1-hmac-sha256",
+        "#{Time.current.iso8601}",
+        "#{OpenSSL::Digest::SHA256.new(authorized_request.canonical_request)}",
+      ].join("\n")
+
+      Timecop.freeze do
+        expect(authorized_request.string_to_sign).to eq signable_string
+      end
+    end
+  end
+
+  describe "#signature" do
+    it "returns a signature" do
+      signed_string = OpenSSL::HMAC.hexdigest(
+        OpenSSL::Digest::SHA256.new,
+        connection.key,
+        authorized_request.string_to_sign,
+      )
+
+      expect(authorized_request.signature).to eq signed_string
+    end
+  end
+
+  describe "#authorization_header" do
+    it "returns the value for the 'Authorization' header" do
+      header = [
+        "x-icims-v1-hmac-sha256 user=#{connection.username}",
+        "signedheaders=content-type;host;x-icims-content-sha256;x-icims-date",
+        "signature=#{authorized_request.signature}",
+      ].join(", ")
+
+      expect(authorized_request.authorization_header).to eq header
+    end
+  end
+
+  describe "#execute" do
+    it "sends the request with the appropriate authorization header" do
+      request = stub_request(
+        :post,
+        post_request.url,
+      ).with(
+        headers: {
+          "Authorization" => authorized_request.authorization_header,
+        }
+      )
+
+      authorized_request.execute
+
+      expect(request).to have_been_requested
+    end
+  end
+
+  def authorized_request(request = post_request)
+    @authorized_request ||= described_class.new(
+      connection: connection,
+      request: request,
+    )
+  end
+
+  def connection
+    @connection ||= build(:icims_connection, :connected)
+  end
+
+  def post_request
+    @request ||= RestClient::Request.new(
+      method: :post,
+      url: "https://api.icims.com/or-whatever",
+      headers: {},
+      data: {}.to_json,
+    )
+  end
+
+  def canonical_request(request)
+    <<-REQUEST.strip_heredoc.strip
+      #{request.method.upcase}
+      /or-ya-know
+      fields=stuff
+      content-type: application/json
+      host: api.icims.com
+      x-icims-content-sha256: #{authorized_request(request).headers["x-icims-content-sha256"]}
+      x-icims-date: #{authorized_request(request).headers["x-icims-date"]}
+
+      content-type;host;x-icims-content-sha256;x-icims-date
+    REQUEST
+  end
+end


### PR DESCRIPTION
This allows the creation of `AuthorizedRequests` to iCIMS, which use iCIMS's wacky implementation of HMAC instead of HTTP basic auth.

This PR *doesn't* swap out HTTP basic auth for HMAC yet.