### PR TITLE
User must have namely field to import candidates

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,6 +1,8 @@
 class DashboardsController < ApplicationController
   def show
-    @jobvite_connection = current_user.jobvite_connection
-    @icims_connection = current_user.icims_connection
+    @connections = [
+      Jobvite::ConnectionPresenter.new(current_user.jobvite_connection),
+      Icims::ConnectionPresenter.new(current_user.icims_connection),
+    ]
   end
 end

--- a/app/presenters/icims/connection_presenter.rb
+++ b/app/presenters/icims/connection_presenter.rb
@@ -1,0 +1,25 @@
+module Icims
+  class ConnectionPresenter < SimpleDelegator
+    include ActiveModel::Conversion
+
+    def self.model_name
+      Connection.model_name
+    end
+
+    def route_key
+      self.class.model_name.singular_route_key
+    end
+
+    def readable_name
+      "iCIMS"
+    end
+
+    def namespace
+      :icims
+    end
+
+    def to_partial_path
+      "dashboards/connection"
+    end
+  end
+end

--- a/app/presenters/jobvite/connection_presenter.rb
+++ b/app/presenters/jobvite/connection_presenter.rb
@@ -1,0 +1,25 @@
+module Jobvite
+  class ConnectionPresenter < SimpleDelegator
+    include ActiveModel::Conversion
+
+    def self.model_name
+      Connection.model_name
+    end
+
+    def route_key
+      self.class.model_name.singular_route_key
+    end
+
+    def readable_name
+      "Jobvite"
+    end
+
+    def namespace
+      :jobvite
+    end
+
+    def to_partial_path
+      "dashboards/connection"
+    end
+  end
+end

--- a/app/views/dashboards/_connection.html.erb
+++ b/app/views/dashboards/_connection.html.erb
@@ -1,0 +1,31 @@
+<tr class="<%= connection.namespace %>-account" %>
+  <% if connection.connected? %>
+    <td>
+      <%= fa_icon "check-circle", class: "connected", text: connection.readable_name %>
+    </td>
+    <td>
+      <% if connection.missing_namely_field? %>
+        <%= t("dashboards.show.missing_namely_field", name: connection.required_namely_field) %>
+      <% end %>
+    </td>
+    <td>
+      <% if connection.found_namely_field? %>
+        <%= button_to t("dashboards.show.import_now"), polymorphic_path([connection.namespace, :imports]), class: "-n-btn" %>
+      <% end %>
+    </td>
+    <td>
+      <%= render "disconnect_button", path: polymorphic_path(connection.route_key) %>
+    </td>
+  <% else %>
+    <td>
+      <%= fa_icon "minus-circle", class: "disconnected", text: connection.readable_name%>
+    </td>
+    <td></td>
+    <td></td>
+    <td>
+      <%= link_to polymorphic_path([:edit, connection.route_key]), class: "-n-btn -n-btn-sm" do %>
+        <%= fa_icon "plug", text: t("dashboards.show.connect") %>
+      <% end %>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -3,70 +3,7 @@
 <section>
   <table>
     <tbody>
-      <tr class="jobvite-account">
-        <% if @jobvite_connection.connected? %>
-          <td>
-            <%= fa_icon "check-circle", class: "connected", text: "Jobvite" %>
-            <p><%= @jobvite_connection.api_key %></p>
-          </td>
-          <td>
-            <% if @jobvite_connection.missing_namely_field? %>
-              <%= t(".missing_namely_field", name: @jobvite_connection.required_namely_field) %>
-            <% end %>
-          </td>
-          <td>
-            <%= button_to t("dashboards.show.import_now"), jobvite_imports_path, class: "-n-btn" %>
-          </td>
-          <td>
-            <%= render "disconnect_button", path: jobvite_connection_path %>
-          </td>
-        <% else %>
-          <td>
-            <%= fa_icon "minus-circle", class: "disconnected", text: "Jobvite" %>
-          </td>
-          <td></td>
-          <td></td>
-          <td>
-            <%= link_to edit_jobvite_connection_path, class: "-n-btn -n-btn-sm" do %>
-              <%= fa_icon "plug", text: t("dashboards.show.connect") %>
-            <% end %>
-          </td>
-        <% end %>
-      </tr>
-      <% if ENV["SHOW_FEATURE"] %>
-      <tr class="icims-account">
-        <% if @icims_connection.connected? %>
-          <td>
-            <%= fa_icon "check-circle", class: "connected", text: "iCIMS" %>
-            <p><%= @icims_connection.username %></p>
-          </td>
-          <td>
-            <% if @icims_connection.missing_namely_field? %>
-              <%= t(".missing_namely_field", name: @icims_connection.required_namely_field) %>
-            <% end %>
-          </td>
-          <td>
-            <%= button_to t("dashboards.show.import_now"), icims_imports_path, class: "-n-btn" %>
-          </td>
-          <td>
-            <%= render "disconnect_button", path: icims_connection_path %>
-          </td>
-        <% else %>
-          <td>
-            <%= fa_icon "minus-circle", class: "disconnected", text: "iCIMS" %>
-          </td>
-          <td>
-          </td>
-          <td>
-          </td>
-          <td>
-            <%= link_to edit_icims_connection_path, class: "-n-btn -n-btn-sm" do %>
-              <%= fa_icon "plug", text: t("dashboards.show.connect") %>
-            <% end %>
-          </td>
-        <% end %>
-      </tr>
-      <% end %>
+      <%= render @connections %>
     </tbody>
   </table>
 </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,7 @@ en:
       disconnect: "Disconnect"
       import_now: "Import now"
       sign_out: "Sign out"
-      missing_namely_field: "You need to add a '%{name}' field to your Namely account to avoid importing the same person multiple times"
+      missing_namely_field: "You need to add a '%{name}' custom field to your Namely account in order to import profiles. This field is used to avoid importing the same candidate multiple times."
 
   date:
     formats:

--- a/spec/features/user_visits_dashboard_spec.rb
+++ b/spec/features/user_visits_dashboard_spec.rb
@@ -9,7 +9,7 @@ feature "User visits their dashboard" do
   end
 
   context "with a Jobvite connection, but no Jobvite field on Namely" do
-    scenario do
+    scenario "user is told that the Jobvite field is missing and isn't shown an import button" do
       stub_namely_request("fields_without_jobvite")
       user = create(:user)
       create(
@@ -22,15 +22,18 @@ feature "User visits their dashboard" do
 
       visit dashboard_path(as: user)
 
-      expect(page).to have_content t(
-        "dashboards.show.missing_namely_field",
-        name: "jobvite_id",
-      )
+      within(".jobvite-account") do
+        expect(page).to have_content t(
+          "dashboards.show.missing_namely_field",
+          name: "jobvite_id",
+        )
+        expect(page).to have_no_button t("dashboards.show.import_now")
+      end
     end
   end
 
   context "with a Jobvite connection, and a Jobvite field on Namely" do
-    scenario do
+    scenario "user can click an import button" do
       stub_namely_request("fields_with_jobvite")
       user = create(:user)
       create(
@@ -42,15 +45,18 @@ feature "User visits their dashboard" do
 
       visit dashboard_path(as: user)
 
-      expect(page).not_to have_content t(
-        "dashboards.show.missing_namely_field",
-        name: "jobvite_id",
-      )
+      within(".jobvite-account") do
+        expect(page).not_to have_content t(
+          "dashboards.show.missing_namely_field",
+          name: "jobvite_id",
+        )
+        expect(page).to have_button t("dashboards.show.import_now")
+      end
     end
   end
 
   context "with a iCIMS connection, but no iCIMS field on Namely" do
-    scenario do
+    scenario "user is told that the iCIMS field is missing and isn't shown an import button" do
       stub_namely_request("fields_without_icims")
       user = create(:user)
       create(
@@ -60,18 +66,20 @@ feature "User visits their dashboard" do
         found_namely_field: false,
       )
 
-
       visit dashboard_path(as: user)
 
-      expect(page).to have_content t(
-        "dashboards.show.missing_namely_field",
-        name: "icims_id",
-      )
+      within(".icims-account") do
+        expect(page).to have_content t(
+          "dashboards.show.missing_namely_field",
+          name: "icims_id",
+        )
+        expect(page).to have_no_button t("dashboards.show.import_now")
+      end
     end
   end
 
   context "with a iCIMS connection, and a iCIMS field on Namely" do
-    scenario do
+    scenario "user can click an import button" do
       stub_namely_request("fields_with_icims")
       user = create(:user)
       create(
@@ -83,10 +91,13 @@ feature "User visits their dashboard" do
 
       visit dashboard_path(as: user)
 
-      expect(page).not_to have_content t(
-        "dashboards.show.missing_namely_field",
-        name: "icims_id",
-      )
+      within(".icims-account") do
+        expect(page).not_to have_content t(
+          "dashboards.show.missing_namely_field",
+          name: "icims_id",
+        )
+        expect(page).to have_button t("dashboards.show.import_now")
+      end
     end
   end
 


### PR DESCRIPTION
* Change copy for missing namely field to be more strict
* Refactor connections on dashboard into partial
* Build presenters for connections to reduce duplication