### PR TITLE
Fix items to work with icims

### DIFF
--- a/app/controllers/icims_candidate_imports_controller.rb
+++ b/app/controllers/icims_candidate_imports_controller.rb
@@ -1,5 +1,6 @@
 class IcimsCandidateImportsController < ApplicationController
   skip_before_filter :require_login
+  skip_before_filter :verify_authenticity_token
 
   def create
     candidate = Icims::Client.new(connection: connection).candidate(person_id)
@@ -27,7 +28,10 @@ class IcimsCandidateImportsController < ApplicationController
   end
 
   def connection
-    Icims::Connection.find_by(customer_id: customer_id)
+    Icims::Connection.find_by(
+      api_key: params[:api_key],
+      customer_id: customer_id,
+    )
   end
 
   def user
@@ -35,10 +39,10 @@ class IcimsCandidateImportsController < ApplicationController
   end
 
   def customer_id
-    params[:data][:customerId]
+    params[:customerId]
   end
 
   def person_id
-    params[:data][:personId]
+    params[:personId]
   end
 end

--- a/app/models/icims/attribute_mapper.rb
+++ b/app/models/icims/attribute_mapper.rb
@@ -10,7 +10,7 @@ module Icims
         gender: namely_gender(icims_candidate.gender),
         salary: icims_candidate.salary,
         home: icims_candidate.home_address,
-        namely_identifier_field => identifier(icims_candidate),
+        namely_identifier_field => identifier(icims_candidate).to_s,
       }.select { |_, value| value.present? }
     end
 

--- a/spec/requests/icims_statuses_spec.rb
+++ b/spec/requests/icims_statuses_spec.rb
@@ -18,7 +18,7 @@ describe "iCIMS new candidate" do
         body: File.read("spec/fixtures/api_responses/not_empty_profiles.json"),
       )
 
-    post icims_candidate_imports_url(connection.api_key), data: import_data
+    post icims_candidate_imports_url(connection.api_key), import_data
 
     expect(response.body).to be_blank
     expect(response.status).to eq 200
@@ -30,7 +30,7 @@ describe "iCIMS new candidate" do
     stub_incomplete_person_results
     connection = user_with_icims_connection
 
-    post icims_candidate_imports_url(connection.api_key), data: import_data
+    post icims_candidate_imports_url(connection.api_key), import_data
 
     expect(response.body).to be_blank
     expect(response.status).to eq 200


### PR DESCRIPTION
* remove CSRF token auth specifically for this end point
* Require baseline authentication by api token
* Fix attribute mapper to send over string instead of number