### PR TITLE
Fix JavaScript tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.2.2
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev qt5-default libqt5webkit5-dev
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev qt5-default libqt5webkit5-dev xvfb
 RUN mkdir /connect
 WORKDIR /connect
 ADD Gemfile /connect/Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :test do
   gem "capybara-webkit", ">= 1.2.0"
   gem "database_cleaner"
   gem "formulaic"
+  gem "headless"
   gem "launchy"
   gem "shoulda-matchers", require: false
   gem "timecop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
       activesupport
       capybara
       i18n
+    headless (2.1.0)
     highline (1.7.1)
     hike (1.2.3)
     honeybadger (2.0.11)
@@ -266,6 +267,7 @@ DEPENDENCIES
   factory_girl_rails
   font-awesome-rails
   formulaic
+  headless
   honeybadger
   i18n-tasks
   jquery-rails

--- a/spec/support/headless.rb
+++ b/spec/support/headless.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  config.around :each, :js do |example|
+    Headless.ly do
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
The JavaScript tests use capybara-webkit, which requires a running X11
server. This adds xvfb to the Docker container and uses the Headless gem
to boot up an xvfb server as needed.