### PR TITLE
Re-raise errors during tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = true
+  config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
This is the default behavior in Rails.

With show_exceptions set to true, integration tests will render a 500
page, hiding the exception and backtrace when an error occurs in a test.

With show_exceptions set to false, integration tests will immediately
fail when an error is raised, making it easier to debug and catch
errors.