### PR TITLE
Refactor connections controllers to a common module

### DIFF
--- a/app/controllers/base_connections_controller.rb
+++ b/app/controllers/base_connections_controller.rb
@@ -1,0 +1,64 @@
+module BaseConnectionsController
+  def edit
+    connection_form
+  end
+
+  def update
+    if connection_form.update(form_params)
+      redirect_to dashboard_path
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    connection.disconnect
+    redirect_to dashboard_path
+  end
+
+  private
+
+  def abstract_method
+    raise UnimplementedAbstractMethod,
+      t(
+        "exceptions.unimplemented_abstract_method",
+        method_name: abstract_method_name
+      )
+  end
+
+  def abstract_method_name
+    caller_locations(1,1)[0].label
+  end
+
+  def client
+    abstract_method
+  end
+
+  def connection_form
+    @connection_form ||= connection_form_class.new(
+      connection: connection
+    )
+  end
+
+  def connection_form_class
+    abstract_method
+  end
+
+  def connection_type
+    abstract_method
+  end
+
+  def form_params_keys
+    abstract_method
+  end
+
+  def form_params
+    params.require(connection_type).permit(form_params_keys)
+  end
+
+  def connection
+    @connection ||= current_user.send(connection_type)
+  end
+
+  class UnimplementedAbstractMethod < StandardError; end
+end

--- a/app/controllers/icims_connections_controller.rb
+++ b/app/controllers/icims_connections_controller.rb
@@ -1,31 +1,18 @@
 class IcimsConnectionsController < ApplicationController
-  def edit
-    icims_connection
-  end
-
-  def update
-    ConnectionUpdater.new(icims_connection_params, icims_connection).update
-    redirect_to dashboard_path
-  rescue ConnectionUpdater::UpdateFailed
-    render :edit
-  end
-
-  def destroy
-    icims_connection.disconnect
-    redirect_to dashboard_path
-  end
+  #require "base_connections_controller"
+  include BaseConnectionsController
 
   private
 
-  def icims_connection_params
-    params.require(:icims_connection).permit(
-      :customer_id,
-      :key,
-      :username,
-    )
+  def connection_type
+    :icims_connection
   end
 
-  def icims_connection
-    @icims_connection ||= current_user.icims_connection
+  def connection_form_class
+    Icims::ConnectionForm
+  end
+
+  def form_params_keys
+    [:customer_id, :key, :username]
   end
 end

--- a/app/controllers/net_suite_connections_controller.rb
+++ b/app/controllers/net_suite_connections_controller.rb
@@ -1,27 +1,18 @@
 class NetSuiteConnectionsController < ApplicationController
-  def edit
-    net_suite_connection_request
-  end
-
-  def update
-    if net_suite_connection_request.update(request_params)
-      redirect_to dashboard_path
-    else
-      render :edit
-    end
-  end
+  #require "base_connections_controller"
+  include BaseConnectionsController
 
   private
 
-  def net_suite_connection_request
-    @net_suite_connection_request ||= NetSuite::ConnectionRequest.new(
-      client: client,
-      connection: net_suite_connection
-    )
+  def connection_type
+    :net_suite_connection
   end
 
-  def net_suite_connection
-    @net_suite_connection ||= current_user.net_suite_connection
+  def connection_form
+    @connection_form ||= NetSuite::ConnectionForm.new(
+      client: client,
+      connection: connection
+    )
   end
 
   def client
@@ -31,9 +22,7 @@ class NetSuiteConnectionsController < ApplicationController
     )
   end
 
-  def request_params
-    params.
-      require(:net_suite_connection).
-      permit(:account_id, :email, :password)
+  def form_params_keys
+    [:account_id, :email, :password]
   end
 end

--- a/app/models/icims/connection_form.rb
+++ b/app/models/icims/connection_form.rb
@@ -1,0 +1,36 @@
+module Icims
+  class ConnectionForm
+    include ActiveModel::Model
+
+    attr_accessor :customer_id, :key, :username
+
+    validates :customer_id, presence: true
+    validates :key, presence: true
+    validates :username, presence: true
+
+    def initialize(connection:)
+      @connection = connection
+    end
+
+    def update(attributes)
+      self.attributes = attributes
+      valid? && @connection.update!(attributes)
+    end
+
+    private
+
+    def attributes
+      {
+        customer_id: customer_id,
+        key: key,
+        username: username
+      }
+    end
+
+    def attributes=(attributes)
+      self.customer_id = attributes[:customer_id]
+      self.key = attributes[:key]
+      self.username = attributes[:username]
+    end
+  end
+end

--- a/app/models/net_suite/connection_form.rb
+++ b/app/models/net_suite/connection_form.rb
@@ -1,5 +1,5 @@
 module NetSuite
-  class ConnectionRequest
+  class ConnectionForm
     include ActiveModel::Model
 
     attr_accessor :account_id, :email, :password

--- a/app/views/icims_connections/edit.html.erb
+++ b/app/views/icims_connections/edit.html.erb
@@ -5,7 +5,13 @@
   <p><%= t(".slogan") %></p>
 </section>
 
-<%= simple_form_for @icims_connection, html: { class: "stacked" } do |f| %>
+<%= simple_form_for(
+  @connection_form,
+  as: :icims_connection,
+  url: icims_connection_path(@connection),
+  method: :put,
+  html: { class: "stacked" }
+) do |f| %>
   <div class="form-row">
     <%= f.input :username, input_html: { class: "half" } %>
   </div>

--- a/app/views/net_suite_connections/edit.html.erb
+++ b/app/views/net_suite_connections/edit.html.erb
@@ -6,7 +6,13 @@
 </section>
 
 <section>
-  <%= simple_form_for @net_suite_connection_request, as: :net_suite_connection, url: net_suite_connection_path(@net_suite_connection), method: :put, html: {class: 'stacked'} do |f| %>
+  <%= simple_form_for(
+    @connection_form,
+    as: :net_suite_connection,
+    url: net_suite_connection_path(@connection),
+    method: :put,
+    html: {class: 'stacked'}
+  ) do |f| %>
     <%= f.error :base %>
     <div class="form-row">
       <%= f.input :account_id, input_html: {class: 'half'} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,9 @@ en:
   subheader:
     slogan: "Namely Connect allows you to seamlessly integrate with 3rd party sites."
 
+  exceptions:
+    unimplemented_abstract_method: "You need to implement #%{method_name} in your connections controller."
+
   helpers:
     submit:
       icims_connection:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -32,15 +32,18 @@ en:
         name: "Name"
         secret_key: "Secret key"
       icims_connection:
-        username: "Username"
-        key: "Key"
         customer_id: "Customer ID"
+        key: "HMAC Key"
+        username: "Username"
       jobvite_connection:
         api_key: "API key"
         secret: "Secret"
       namely_authentication:
         subdomain: yourcompany
-
+      net_suite_connection:
+        account_id: "Account ID"
+        email: "Email"
+        password: "Password"
 
     # Examples
     # labels:

--- a/spec/models/icims/connection_form_spec.rb
+++ b/spec/models/icims/connection_form_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe Icims::ConnectionForm do
+  describe "#update" do
+    context "with valid information" do
+      it "updates the connection from the response" do
+        connection = stub_connection(success: true)
+        request_attributes = valid_request_attributes
+        request = Icims::ConnectionForm.new(
+          connection: connection,
+        )
+
+        result = request.update(request_attributes)
+
+        expect(result).to eq(true)
+        expect(connection).to have_received(:update!).with(
+          customer_id: 1,
+          key: "def",
+          username: "bob"
+        )
+      end
+    end
+
+    context "with invalid fields" do
+      it "adds validation messages" do
+        connection = stub_connection(success: false)
+        request = Icims::ConnectionForm.new(
+          connection: connection,
+        )
+
+        result = request.update({})
+
+        expect(result).to eq(false)
+        expect(connection).not_to have_received(:update!)
+        expect(request.errors.full_messages).to match_array([
+          "Customer can't be blank",
+          "Key can't be blank",
+          "Username can't be blank"
+        ])
+      end
+    end
+  end
+
+  def valid_request_attributes
+    { customer_id: 1, key: "def", username: "bob" }
+  end
+
+  def stub_connection(success: true)
+    double(Icims::Connection).tap do |connection|
+      allow(connection).to receive(:update!).and_return(success)
+    end
+  end
+end

--- a/spec/models/net_suite/connection_form_spec.rb
+++ b/spec/models/net_suite/connection_form_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-describe NetSuite::ConnectionRequest do
+describe NetSuite::ConnectionForm do
   describe "#update" do
     context "with valid information" do
       it "updates the connection from the response" do
         client = stub_client(success: true, id: "abc", token: "def")
         request_attributes = valid_request_attributes
         connection = stub_connection
-        request = NetSuite::ConnectionRequest.new(
+        request = NetSuite::ConnectionForm.new(
           connection: connection,
           client: client
         )
@@ -28,7 +28,7 @@ describe NetSuite::ConnectionRequest do
       it "adds validation messages" do
         client = stub_client(success: true)
         connection = stub_connection
-        request = NetSuite::ConnectionRequest.new(
+        request = NetSuite::ConnectionForm.new(
           connection: connection,
           client: client
         )
@@ -50,7 +50,7 @@ describe NetSuite::ConnectionRequest do
       it "adds validation errors from the server" do
         client = stub_client(success: false, message: "oops")
         connection = stub_connection
-        request = NetSuite::ConnectionRequest.new(
+        request = NetSuite::ConnectionForm.new(
           connection: connection,
           client: client
         )


### PR DESCRIPTION
* Implements base_connections_controller as a module
  * Moves common functionality into that module, with necessary
    methods on the concrete controllers implemented to raise an
    exception if the concrete controller does not implement that method
* Adds Icims::ConnectionRequest form object, which makes the refactoring
  feasible
* DRYs out NetSuiteConnectionController and IcimsConnectionController
* Other ConnectionControllers to follow
* The other controllers will also necessitate implementing the
  corresponding ::ConnectionRequest classes
* For: https://trello.com/c/VEnA88Nf/30