### PR TITLE
Improve Docker configuration

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,10 +2,12 @@ development: &default
   adapter: postgresql
   database: connect_development
   encoding: utf8
-  host: localhost
+  host: db
   min_messages: warning
-  pool: 2
+  pool: 10
+  port: 5432
   timeout: 5000
+  user: postgres
 
 test:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,23 +4,7 @@ db:
    - "5432"
 web:
   build: .
-  command: bundle exec rails s -p 3000 -b '0.0.0.0'
-  environment:
-    DATABASE_URL: "postgres://postgres:@db:5432/connect_development?pool=10"
-    RAILS_ENV: "development"
-    RACK_ENV: development
-    SECRET_KEY_BASE: development_secret
-    NAMELY_CLIENT_ID: client_id
-    NAMELY_CLIENT_SECRET: secret
-    CLOUD_ELEMENTS_ORGANIZATION_SECRET: aa
-    CLOUD_ELEMENTS_USER_SECRET: aa
-    HOST: http://host
-    TEST_JOBVITE_KEY: aa
-    TEST_JOBVITE_SECRET: aa
-    TEST_NAMELY_ACCESS_TOKEN: aa
-    TEST_NAMELY_AUTH_CODE: aa
-    TEST_NAMELY_SUBDOMAIN: aa
-    TEST_NAMELY_REFRESH_TOKEN: aa
+  command: bundle exec unicorn -p 3000 -c ./config/unicorn.rb
   volumes:
    - .:/connect
   ports:


### PR DESCRIPTION
Specifying the environment in docker-compose.yml made it impossible to
override secret keys in local .env files. Also, specifying the RAILS_ENV
and DATABASE_URL caused the development server and test to run in the
same database, meaning that running tests would wipe development data.

This also switches from Webrick to Unicorn, which is much faster and
doesn't hang when the Docker container goes to sleep.