### PR TITLE
Extract duplication from Namely field check

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,10 +1,18 @@
 class DashboardsController < ApplicationController
   def show
-    @connections = [
+    @connections = decorate([
       Jobvite::ConnectionPresenter.new(current_user.jobvite_connection),
       Icims::ConnectionPresenter.new(current_user.icims_connection),
       Greenhouse::ConnectionPresenter.new(current_user.greenhouse_connection),
       NetSuite::ConnectionPresenter.new(current_user.net_suite_connection)
-    ]
+    ])
+  end
+
+  private
+
+  def decorate(connections)
+    connections.map do |connection|
+      UserCheckNamelyField.new(connection)
+    end
   end
 end

--- a/app/models/greenhouse/connection.rb
+++ b/app/models/greenhouse/connection.rb
@@ -9,12 +9,6 @@ module Greenhouse
       name.present?
     end
 
-    def missing_namely_field?
-      if connected?
-        UserCheckNamelyField.new(self).check?
-      end
-    end
-
     def disconnect
       update(name: nil)
     end

--- a/app/models/icims/connection.rb
+++ b/app/models/icims/connection.rb
@@ -21,12 +21,6 @@ module Icims
       )
     end
 
-    def missing_namely_field?
-      if connected?
-        UserCheckNamelyField.new(self).check?
-      end
-    end
-
     def required_namely_field
       AttributeMapper.new.namely_identifier_field.to_s
     end

--- a/app/models/jobvite/connection.rb
+++ b/app/models/jobvite/connection.rb
@@ -15,12 +15,6 @@ module Jobvite
       )
     end
 
-    def missing_namely_field?
-      if connected?
-        UserCheckNamelyField.new(self).check?
-      end
-    end
-
     def required_namely_field
       AttributeMapper.new.namely_identifier_field.to_s
     end

--- a/app/services/user_check_namely_field.rb
+++ b/app/services/user_check_namely_field.rb
@@ -1,19 +1,33 @@
 class UserCheckNamelyField < SimpleDelegator
-  def check?
-    if namely_field_not_found? && namely_account_has_required_field?
-      update(found_namely_field: true)
-    end
-    namely_field_not_found?
+  def missing_namely_field?
+    disconnected? || does_not_have_field?
   end
 
   private
 
-  def namely_field_not_found?
-    !found_namely_field?
+  def disconnected?
+    !connected?
   end
 
-  def namely_account_has_required_field?
-    namely_connection.fields.all.detect do |field|
+  def does_not_have_field?
+    !has_field?
+  end
+
+  def has_field?
+    found_namely_field? || has_cached_remote_field?
+  end
+
+  def has_cached_remote_field?
+    if has_remote_field?
+      update(found_namely_field: true)
+      true
+    else
+      false
+    end
+  end
+
+  def has_remote_field?
+    namely_connection.fields.all.any? do |field|
       field.name == required_namely_field
     end
   end

--- a/spec/models/greenhouse/connection_spec.rb
+++ b/spec/models/greenhouse/connection_spec.rb
@@ -29,18 +29,6 @@ RSpec.describe Greenhouse::Connection, :type => :model do
     end
   end
 
-  describe "#missing_namely_field?" do
-    it "doesn't check when not connected" do
-      greenhouse_connection = described_class.new
-      allow(greenhouse_connection).to receive(:check_namely_field)
-
-      greenhouse_connection.missing_namely_field?
-
-      expect(greenhouse_connection).not_to have_received(:check_namely_field)
-    end
-
-  end
-
   describe "#disconnect" do
     let(:greenhouse_connection) { create :greenhouse_connection,
                                   :connected, name: "crashoverride" }

--- a/spec/models/jobvite/connection_spec.rb
+++ b/spec/models/jobvite/connection_spec.rb
@@ -38,62 +38,6 @@ describe Jobvite::Connection do
     end
   end
 
-  describe "#missing_namely_field?" do
-    context "when the connection is not connected to Jobvite" do
-      it "returns false" do
-        connection = create(
-          :jobvite_connection,
-          :disconnected,
-          found_namely_field: false,
-        )
-
-        expect(connection).not_to be_missing_namely_field
-      end
-    end
-
-    context "when the field hasn't previously been found and does not exist" do
-      it "returns true" do
-        connection = create(
-          :jobvite_connection,
-          :connected,
-          found_namely_field: false,
-        )
-        stub_namely_connection(connection.user, field_names: [])
-
-        expect(connection).to be_missing_namely_field
-        expect(connection.reload.found_namely_field).to eq false
-      end
-    end
-
-    context "when the field hasn't previously been found but does exist" do
-      it "returns false and updates the connection" do
-        connection = create(
-          :jobvite_connection,
-          :connected,
-          found_namely_field: false,
-        )
-        stub_namely_connection(connection.user, field_names: ["jobvite_id"])
-
-        expect(connection).not_to be_missing_namely_field
-        expect(connection.reload.found_namely_field).to eq true
-      end
-    end
-
-    context "when the field has previously been found" do
-      it "returns false without hitting the Namely API" do
-        connection = create(
-          :jobvite_connection,
-          :connected,
-          found_namely_field: true,
-        )
-        stub_namely_connection(connection.user, field_names: ["jobvite_id"])
-
-        expect(connection).not_to be_missing_namely_field
-        expect(connection.user).not_to have_received(:namely_connection)
-      end
-    end
-  end
-
   def stub_namely_connection(user, field_names:)
     fields = field_names.map { |name| double("field", name: name) }
     fields_collection = double("fields", all: fields)

--- a/spec/services/user_check_namely_field_spec.rb
+++ b/spec/services/user_check_namely_field_spec.rb
@@ -1,24 +1,93 @@
-require_relative '../../app/services/user_check_namely_field'
+require "spec_helper"
+require_relative "../../app/services/user_check_namely_field"
 
 describe UserCheckNamelyField do
-  subject(:user_check_namely_field) { described_class.new(connection) }
-  let(:connection) { double(
-    :connection,
-    found_namely_field?: found,
-    user: user,
-    required_namely_field: :field_name) }
-  let(:user) { double :user, namely_connection: namely_connection }
-  let(:namely_connection) { double(:namely_connection, fields: fields) }
+  describe "#missing_namely_field?" do
+    context "connected and defined but not previously found" do
+      it "returns false and updates the found namely field" do
+        connection = stub_connection(
+          fields: %i(field_name),
+          found: false,
+          required_field: :field_name
+        )
 
-  describe '#check?' do
-    context 'when namely field not found and namely account has required field' do
-      let(:found) { false }
-      let(:fields) { double :fields, all: [double(:field, name: :field_name)]}
+        result = check(connection).missing_namely_field?
 
-      it 'update found namely field' do
-        expect(connection).to receive(:update).with(found_namely_field: true)
-        user_check_namely_field.check?
+        expect(result).to eq(false)
+        expect(connection).to have_received(:update).
+          with(found_namely_field: true)
       end
     end
+
+    context "previously found" do
+      it "returns false without updating" do
+        connection = stub_connection(
+          fields: %i(field_name),
+          found: true,
+          required_field: :field_name
+        )
+
+        result = check(connection).missing_namely_field?
+
+        expect(result).to eq(false)
+        expect(connection).not_to have_received(:update)
+      end
+    end
+
+    context "disconnected" do
+      it "returns true" do
+        connection = double(:connection, connected?: false)
+
+        result = check(connection).missing_namely_field?
+
+        expect(result).to eq(true)
+      end
+    end
+
+    context "connected and undefined" do
+      it "returns true" do
+        connection = stub_connection(
+          fields: %i(other_field_name),
+          found: false,
+          required_field: :expected_field_name
+        )
+
+        result = check(connection).missing_namely_field?
+
+        expect(result).to eq(true)
+        expect(connection).not_to have_received(:update)
+      end
+    end
+  end
+
+  def stub_connection(found:, fields:, required_field:)
+    double(
+      :connection,
+      connected?: true,
+      found_namely_field?: found,
+      required_namely_field: required_field,
+      update: true,
+      user: stub_user(fields)
+    )
+  end
+
+  def stub_user(fields)
+    double(:user, namely_connection: stub_namely_connection(fields))
+  end
+
+  def stub_namely_connection(fields)
+    double(:namely_connection, fields: stub_fields_named(fields))
+  end
+
+  def stub_fields_named(names)
+    fields = names.map do |name|
+      double(:field, name: name)
+    end
+
+    double(:fields, all: fields)
+  end
+
+  def check(connection)
+    UserCheckNamelyField.new(connection)
   end
 end


### PR DESCRIPTION
Each connection implements its own check for Namely fields, which
requires copying and pasting boilerplate code into each new integration.

This extracts the common code and uses the existing decorator in the
view so that new drivers only need to define the required field.

Also extends test coverage for the UserCheckNamelyField class.