### PR TITLE
Record NetSuite internalIDs on Namely profiles

### DIFF
--- a/app/models/net_suite/export.rb
+++ b/app/models/net_suite/export.rb
@@ -31,6 +31,11 @@ module NetSuite
         gender: profile.gender,
         phone: profile.home_phone
       )
+
+      if response.success?
+        profile.update(netsuite_id: response["internalId"])
+      end
+
       Result.new(response, profile)
     end
 

--- a/spec/features/user_exports_to_net_suite_spec.rb
+++ b/spec/features/user_exports_to_net_suite_spec.rb
@@ -4,6 +4,7 @@ feature "user exports to net suite" do
   scenario "successfully" do
     user = create(:user)
     stub_namely_data("/profiles", "profiles_with_net_suite_fields")
+    stub_request(:put, %r{.*api/v1/profiles/.*}).to_return(status: 200)
     stub_request(
       :post,
       "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees"


### PR DESCRIPTION
This allows us to correlate which profile corresponds to which employee.

https://trello.com/c/MYmNpTNo