### PR TITLE
Update existing employees during NetSuite export

### DIFF
--- a/app/models/net_suite/client.rb
+++ b/app/models/net_suite/client.rb
@@ -14,7 +14,8 @@ module NetSuite
     end
 
     def create_instance(params)
-      post_json(
+      submit_json(
+        :post,
         "/instances",
         "configuration" => {
           "user.username" => params[:email],
@@ -31,8 +32,22 @@ module NetSuite
     end
 
     def create_employee(params)
-      post_json(
+      submit_json(
+        :post,
         "/hubs/erp/employees",
+        "firstName" => params[:first_name],
+        "lastName" => params[:last_name],
+        "email" => params[:email],
+        "gender" => map_gender(params[:gender]),
+        "phone" => params[:phone],
+        "subsidiary" => { "internalId" => 1 }
+      )
+    end
+
+    def update_employee(id, params)
+      submit_json(
+        :patch,
+        "/hubs/erp/employees/#{id}",
         "firstName" => params[:first_name],
         "lastName" => params[:last_name],
         "email" => params[:email],
@@ -44,9 +59,10 @@ module NetSuite
 
     private
 
-    def post_json(path, data)
+    def submit_json(method, path, data)
       wrap_response do
-        RestClient.post(
+        RestClient.public_send(
+          method,
           url(path),
           data.to_json,
           authorization: authorization,

--- a/app/views/net_suite_exports/_export.html.erb
+++ b/app/views/net_suite_exports/_export.html.erb
@@ -1,0 +1,6 @@
+<% if employee.updated? %>
+  Exported updates for employee:
+<% else %>
+  Exported new employee:
+<% end %>
+<%= employee.first_name %> <%= employee.last_name %>

--- a/app/views/net_suite_exports/_result.html.erb
+++ b/app/views/net_suite_exports/_result.html.erb
@@ -1,6 +1,6 @@
 <p>
   <% if result.success? %>
-    Exported new employee: <%= result.first_name %> <%= result.last_name %>
+    <%= render "export", employee: result %>
   <% else %>
     Couldn't export: <%= result.first_name %> <%= result.last_name %>
     (<%= result.message %>)

--- a/spec/features/user_exports_to_net_suite_spec.rb
+++ b/spec/features/user_exports_to_net_suite_spec.rb
@@ -12,6 +12,12 @@ feature "user exports to net suite" do
       with(body: /Sally/).
       to_return(status: 200, body: { "internalId" => "123" }.to_json)
     stub_request(
+      :patch,
+      "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees/1234"
+    ).
+      with(body: /Tina/).
+      to_return(status: 200, body: { "internalId" => "1234" }.to_json)
+    stub_request(
       :post,
       "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees"
     ).
@@ -23,10 +29,10 @@ feature "user exports to net suite" do
 
     find(".net-suite-account").click_on t("dashboards.show.export_now")
 
-    expect(page).to have_content("Processed 2 employees")
+    expect(page).to have_content("Processed 3 employees")
     expect(page).to have_content("Exported new employee: Sally Smith")
+    expect(page).to have_content("Exported updates for employee: Tina Tech")
     expect(page).to have_content("Couldn't export: Mickey Moore")
     expect(page).to have_content("Bad Data")
-    expect(page).not_to have_content("Tina Tech")
   end
 end

--- a/spec/models/net_suite/client_spec.rb
+++ b/spec/models/net_suite/client_spec.rb
@@ -114,4 +114,52 @@ describe NetSuite::Client do
       end
     end
   end
+
+  describe "#update_employee" do
+    context "on HTTP success" do
+      it "returns successful data" do
+        employee = { internalId: "1949" }
+        stub_request(
+          :patch,
+          "https://api.cloud-elements.com/elements/api-v2" \
+          "/hubs/erp/employees/1949"
+        ).
+          with(
+            body: {
+              firstName: "Sally",
+              lastName: "Sitwell",
+              email: "sally@example.com",
+              gender: "_female",
+              phone: "123-123-1234",
+              subsidiary: { internalId: 1 }
+            }.to_json,
+            headers: {
+              "Authorization" => "User user-secret, " \
+                "Organization org-secret, " \
+                "Element element-secret",
+              "Content-Type" => "application/json"
+            }
+          ).
+          to_return(status: 200, body: employee.to_json)
+
+        client = NetSuite::Client.new(
+          user_secret: "user-secret",
+          organization_secret: "org-secret",
+          element_secret: "element-secret"
+        )
+
+        result = client.update_employee(
+          employee[:internalId],
+          email: "sally@example.com",
+          first_name: "Sally",
+          last_name: "Sitwell",
+          gender: "Female",
+          phone: "123-123-1234"
+        )
+
+        expect(result).to be_success
+        expect(result["internalId"]).to eq("1949")
+      end
+    end
+  end
 end


### PR DESCRIPTION
When exporting a profile that was previously exported, update the
corresponding employee record in NetSuite.

https://trello.com/c/MYmNpTNo