### PR TITLE
Export to every connected NetSuite account

### DIFF
--- a/app/controllers/net_suite_exports_controller.rb
+++ b/app/controllers/net_suite_exports_controller.rb
@@ -1,7 +1,7 @@
 class NetSuiteExportsController < ApplicationController
   def create
     export = NetSuite::Export.new(
-      namely_profiles: current_user.namely_connection.profiles.all,
+      namely_profiles: current_user.namely_profiles.all,
       net_suite: current_user.net_suite_connection.client
     )
     @results = export.perform

--- a/app/models/net_suite/bulk_export.rb
+++ b/app/models/net_suite/bulk_export.rb
@@ -1,0 +1,16 @@
+module NetSuite
+  class BulkExport
+    def initialize(users)
+      @users = users
+    end
+
+    def export
+      @users.ready_to_sync_with(:net_suite).each do |user|
+        Export.new(
+          namely_profiles: user.namely_profiles.all,
+          net_suite: user.net_suite_connection.client
+        ).perform
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,12 @@ class User < ActiveRecord::Base
   has_one :greenhouse_connection, class_name: "Greenhouse::Connection"
   has_one :net_suite_connection, class_name: "NetSuite::Connection"
 
+  def self.ready_to_sync_with(integration)
+    association = "#{integration}_connection"
+    joins(association.to_sym).
+      where(association.pluralize => { found_namely_field: true })
+  end
+
   def full_name
     Users::UserWithFullName.new(self).full_name
   end
@@ -22,6 +28,14 @@ class User < ActiveRecord::Base
 
   def net_suite_connection
     super || NetSuite::Connection.create(user: self)
+  end
+
+  def namely_profiles
+    namely_connection.profiles
+  end
+
+  def namely_fields
+    namely_connection.fields
   end
 
   def namely_connection

--- a/app/services/greenhouse/candidates_importer.rb
+++ b/app/services/greenhouse/candidates_importer.rb
@@ -53,7 +53,7 @@ module Greenhouse
       NamelyImporter.new(
         namely_connection: user.namely_connection,
         attribute_mapper: Greenhouse::AttributeMapper.new(
-          user.namely_connection.fields.all
+          user.namely_fields.all
         )
       )
     end

--- a/lib/tasks/net_suite.rake
+++ b/lib/tasks/net_suite.rake
@@ -1,0 +1,6 @@
+namespace :net_suite do
+  desc "Export Namely profiles to NetSuite for all users"
+  task export: :environment do
+    NetSuite::BulkExport.new(User.all).export
+  end
+end

--- a/lib/tasks/user_emails.rake
+++ b/lib/tasks/user_emails.rake
@@ -2,7 +2,7 @@ namespace :user do
   desc "Bring on emails for every user"
   task emails: :environment do
     User.all.each do |user|
-      profile = user.namely_connection.profiles.find(user.namely_user_id)
+      profile = user.namely_profiles.find(user.namely_user_id)
       if user.email.nil? && profile.email
         user.update(email: profile.email)
       end

--- a/spec/models/net_suite/bulk_export_spec.rb
+++ b/spec/models/net_suite/bulk_export_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe NetSuite::BulkExport do
+  include Features
+
+  describe "#export" do
+    context "with a fully connected user" do
+      it "creates an export for every user with a NetSuite connection" do
+        user = create(:user)
+        create(
+          :net_suite_connection,
+          :connected,
+          :with_namely_field,
+          user: user
+        )
+        stub_namely_data("/profiles", "profiles_with_net_suite_fields")
+        stub_request(:put, %r{.*api/v1/profiles/.*}).to_return(status: 200)
+        stub_request(:any, %r{.*/api-v2/hubs/erp/employees.*}).
+          to_return(status: 200, body: { "internalId" => "123" }.to_json)
+
+        export user
+
+        expect(WebMock).to have_requested(
+          :post,
+          "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees"
+        ).twice
+      end
+    end
+
+    context "with a user without a mapped Namely field" do
+      it "doesn't export" do
+        user = create(:user)
+        create(
+          :net_suite_connection,
+          :connected,
+          found_namely_field: false,
+          user: user
+        )
+
+        export user
+
+        expect(WebMock).not_to have_requested(:post, %r{.*})
+      end
+    end
+
+    context "with a disconnected user" do
+      it "doesn't export" do
+        user = create(:user)
+
+        export user
+
+        expect(WebMock).not_to have_requested(:post, %r{.*})
+      end
+    end
+
+    def export(*users)
+      NetSuite::BulkExport.new(User.where(id: users)).export
+    end
+  end
+end

--- a/spec/services/greenhouse/candidates_importer_spec.rb
+++ b/spec/services/greenhouse/candidates_importer_spec.rb
@@ -13,10 +13,14 @@ describe Greenhouse::CandidatesImporter do
   let(:secret_key) { 'secret_key' }
   let(:signature) { '120 signature' }
   let(:connection_repo) { double :connection_repo, find_by: connection }
-  let(:user) { double :user, namely_connection: namely_connection }
-  let(:namely_connection) do
-    double(:namely_connection, fields: double(:fields, all: namely_fields))
+  let(:user) do
+    double(
+      :user,
+      namely_connection: namely_connection,
+      namely_fields: double(:fields, all: namely_fields)
+    )
   end
+  let(:namely_connection) { double(:namely_connection) }
   let(:connection) { double :connection, user: user }
   subject(:candidates_importer) { described_class.new(mailer,
                                                       connection_repo,


### PR DESCRIPTION
Adds a rake task to run an export for every NetSuite connection. Can be
used by Heroku scheduler to regularly run exports and keep Namely in
sync with NetSuite.

https://trello.com/c/k0OIdkkF