### PR TITLE
Provide a notification when a user disconnects an integration

### DIFF
--- a/app/controllers/jobvite_imports_controller.rb
+++ b/app/controllers/jobvite_imports_controller.rb
@@ -1,6 +1,9 @@
 class JobviteImportsController < ApplicationController
   def create
     @jobvite_imports_presenter = ImportsPresenter.new(importer.import)
+  rescue Jobvite::Client::Unauthorized
+    flash[:error] = t("jobvite_connections.authentication_error")
+    redirect_to dashboard_path
   end
 
   private

--- a/app/mailers/connection_mailer.rb
+++ b/app/mailers/connection_mailer.rb
@@ -1,0 +1,19 @@
+class ConnectionMailer < ApplicationMailer
+  def authentication_notification(connection_type:, email:)
+    @integration = map_connection_type_to_integration(connection_type)
+
+    mail(
+      to: email,
+      subject: t(
+        "connection_mailer.authentication_notification.subject",
+        integration: @integration
+      )
+    )
+  end
+
+  private
+
+  def map_connection_type_to_integration(connection_type)
+    t("connection_mailer.integration_mapping.#{connection_type}")
+  end
+end

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -26,7 +26,7 @@ class NetSuite::Connection < ActiveRecord::Base
   end
 
   def client
-    NetSuite::Client.from_env.authorize(authorization)
+    NetSuite::Client.from_env(user).authorize(authorization)
   end
 
   def disconnect

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,4 +54,11 @@ class User < ActiveRecord::Base
     self.access_token_expiry = Users::TokenExpiry.for(access_token_expires_in)
     save
   end
+
+  def send_connection_notification(connection_type)
+    ConnectionMailer.authentication_notification(
+      connection_type: connection_type,
+      email: email
+    ).deliver
+  end
 end

--- a/app/views/connection_mailer/authentication_notification.en.text.erb
+++ b/app/views/connection_mailer/authentication_notification.en.text.erb
@@ -1,0 +1,3 @@
+<%= t(".notice", integration: @integration) -%>
+
+Namely

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,21 @@ en:
       sign_in:
         prompt: "Sign in using"
 
+  connection_mailer:
+    authentication_notification:
+      notice: |
+        Your Namely Connect connection to %{integration} is raising an
+        authentication error.
+
+        Please check your account credentials for %{integration} in
+        Namely Connect.
+      subject: "Namely Connect: %{integration} has an authentication error"
+    integration_mapping:
+      greenhouse: "Greenhouse"
+      icims: "iCIMS"
+      jobvite: "Jobvite"
+      net_suite: "NetSuite"
+
   greenhouse_connections:
     description:
       connected_html: >
@@ -111,6 +126,9 @@ en:
       reason: "Reason"
 
   jobvite_connections:
+    authentication_error: >
+      Your Jobvite credentials appear to be invalid. Please disconnect Jobvite,
+      then reconnect Jobvite with updated credentials.
     description:
       connected_html: >
         <a href="http://www.jobvite.com/">Jobvite</a> is the leading recruiting
@@ -152,6 +170,7 @@ en:
       title: "NetSuite"
       slogan: >
         Please fill out the following fields to finalize this connection.
+
   net_suite_exports:
     create:
       title: "Exporting to NetSuite"

--- a/spec/mailers/connection_mailer_spec.rb
+++ b/spec/mailers/connection_mailer_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe ConnectionMailer do
+  it "provides integration name in the subject, addresses the email, and " \
+  "describes the problem" do
+    connection_type = "icims"
+    email = "test@example.com"
+    mailer = ConnectionMailer.authentication_notification(
+      connection_type: connection_type,
+      email: email
+    )
+
+    expect(mailer.subject).to eq(
+      t(
+        "connection_mailer.authentication_notification.subject",
+        integration: "iCIMS"
+      )
+    )
+    expect(mailer.to).to match_array([email])
+    expect(mailer.body.to_s).to include(
+      t(
+        "connection_mailer.authentication_notification.notice",
+        integration: "iCIMS"
+      )
+    )
+  end
+end

--- a/spec/models/icims/candidate_find_spec.rb
+++ b/spec/models/icims/candidate_find_spec.rb
@@ -9,8 +9,9 @@ describe Icims::CandidateFind do
 
       connection = double(
         "icims_connection",
-        key: "MY_KEY",
         api_url: icims_customer_api_url,
+        key: "MY_KEY",
+        user: double(User),
         username: "USERNAME",
       )
 

--- a/spec/models/icims/candidate_search_spec.rb
+++ b/spec/models/icims/candidate_search_spec.rb
@@ -9,6 +9,7 @@ describe Icims::CandidateSearch do
         "icims_connection",
         api_url: icims_customer_api_url,
         key: "MY_KEY",
+        user: double(User),
         username: "USERNAME",
       )
 

--- a/spec/models/icims/client_spec.rb
+++ b/spec/models/icims/client_spec.rb
@@ -23,8 +23,9 @@ describe Icims::Client do
             )
           connection = double(
             "icims_connection",
-            key: "MY_KEY",
             api_url: icims_customer_api_url,
+            key: "MY_KEY",
+            user: user_double,
             username: "USERNAME",
           )
           client = described_class.new(connection)
@@ -53,8 +54,9 @@ describe Icims::Client do
             )
           connection = double(
             "icims_connection",
-            key: "MY_KEY",
             api_url: icims_customer_api_url,
+            key: "MY_KEY",
+            user: user_double,
             username: "USERNAME",
           )
 
@@ -72,10 +74,12 @@ describe Icims::Client do
 
         connection = double(
           "icims_connection",
-          key: "MY_KEY",
           api_url: icims_customer_api_url,
+          key: "MY_KEY",
+          user: user_double,
           username: "USERNAME",
         )
+
         client = described_class.new(connection)
 
         expect { client.recent_hires }.
@@ -99,5 +103,9 @@ describe Icims::Client do
       lastname: "Doe",
       firstname: "Jane",
     }.merge(values).to_json
+  end
+
+  def user_double
+    build_stubbed(:user)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -71,6 +71,21 @@ describe User do
     end
   end
 
+  describe "#send_connection_notification" do
+    it "sends an invalid authentication message" do
+      user = build_stubbed(:user)
+      mail = double(ConnectionMailer, deliver: true)
+      allow(ConnectionMailer).
+        to receive(:authentication_notification).
+        with(email: user.email, connection_type: "icims").
+        and_return(mail)
+
+      user.send_connection_notification("icims")
+
+      expect(mail).to have_received(:deliver)
+    end
+  end
+
   describe '#save_token_info' do 
     let(:user) { create :user }
 

--- a/spec/support/features/messages_helper.rb
+++ b/spec/support/features/messages_helper.rb
@@ -1,0 +1,5 @@
+module Features
+  def have_error_message(message)
+    have_css("#flash_error", text: message)
+  end
+end


### PR DESCRIPTION
* In place for Greenhouse, iCIMS, Jobvite and NetSuite
  * NetSuite doesn't have its disconnect functionality wired in yet,
    so the functionality there is not wrapped with a test
  * I'm not overly worried about that fact since the same functionality
    is well covered with the disconnect feature specs for the other
    three current integrations
* Subsequent integrations will need to be added to INTEGRATION_MAP
  in ConnectionsController
* For: https://trello.com/c/fZ9WQynV/