### PR TITLE
Require a subsidiary after connecting NetSuite

### DIFF
--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -6,9 +6,22 @@ class ConnectionsController < ApplicationController
 
   def create
     if connection_form.update(form_params)
-      redirect_to dashboard_path
+      redirect_to after_save_path
     else
       render new_template
+    end
+  end
+
+  def edit
+    connection
+    render edit_template
+  end
+
+  def update
+    if connection.update(form_params)
+      redirect_to after_save_path
+    else
+      render edit_template
     end
   end
 
@@ -32,6 +45,18 @@ class ConnectionsController < ApplicationController
 
   def new_template
     form_type.pluralize + "/new"
+  end
+
+  def edit_template
+    form_type.pluralize + "/edit"
+  end
+
+  def after_save_path
+    if connection.ready?
+      dashboard_path
+    else
+      edit_connection_path(form_type)
+    end
   end
 
   def form_params

--- a/app/jobs/net_suite_export_job.rb
+++ b/app/jobs/net_suite_export_job.rb
@@ -12,6 +12,7 @@ class NetSuiteExportJob
 
   def export
     NetSuite::Export.new(
+      configuration: user.net_suite_connection,
       namely_profiles: user.namely_profiles.all,
       net_suite: user.net_suite_connection.client
     ).perform

--- a/app/models/greenhouse/connection.rb
+++ b/app/models/greenhouse/connection.rb
@@ -9,6 +9,10 @@ module Greenhouse
       name.present?
     end
 
+    def ready?
+      true
+    end
+
     def disconnect
       update(name: nil)
     end

--- a/app/models/icims/connection.rb
+++ b/app/models/icims/connection.rb
@@ -9,6 +9,10 @@ module Icims
       username.present? && key.present? && customer_id.present?
     end
 
+    def ready?
+      true
+    end
+
     def api_url
       "https://api.icims.com/customers/#{customer_id}"
     end

--- a/app/models/jobvite/connection.rb
+++ b/app/models/jobvite/connection.rb
@@ -8,6 +8,10 @@ module Jobvite
       api_key.present? && secret.present?
     end
 
+    def ready?
+      true
+    end
+
     def disconnect
       update(
         api_key: nil,

--- a/app/models/net_suite/client.rb
+++ b/app/models/net_suite/client.rb
@@ -57,6 +57,10 @@ module NetSuite
       )
     end
 
+    def subsidiaries
+      get_json("/hubs/erp/lookups/subsidiary")
+    end
+
     private
 
     def submit_json(method, path, data)
@@ -65,6 +69,16 @@ module NetSuite
           method,
           url(path),
           data.to_json,
+          authorization: authorization,
+          content_type: "application/json"
+        )
+      end
+    end
+
+    def get_json(path)
+      wrap_response do
+        RestClient.get(
+          url(path),
           authorization: authorization,
           content_type: "application/json"
         )
@@ -98,6 +112,8 @@ module NetSuite
     end
 
     class Result
+      include Enumerable
+
       def initialize(success, response)
         @success = success
         @response = response
@@ -108,13 +124,17 @@ module NetSuite
       end
 
       def [](attribute)
-        json[attribute]
+        json[attribute.to_s]
+      end
+
+      def each(&block)
+        json.each(&block)
       end
 
       private
 
       def json
-        @json ||= JSON.parse(@response).with_indifferent_access
+        @json ||= JSON.parse(@response)
       end
     end
 

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -1,6 +1,8 @@
 class NetSuite::Connection < ActiveRecord::Base
   belongs_to :user
 
+  validates :subsidiary_id, presence: true, allow_nil: true
+
   def connected?
     instance_id.present? && authorization.present?
   end
@@ -9,8 +11,18 @@ class NetSuite::Connection < ActiveRecord::Base
     ENV["CLOUD_ELEMENTS_ORGANIZATION_SECRET"].present?
   end
 
+  def ready?
+    subsidiary_id.present?
+  end
+
   def required_namely_field
     :netsuite_id
+  end
+
+  def subsidiaries
+    client.
+      subsidiaries.
+      map { |subsidiary| [subsidiary["name"], subsidiary["internalId"]] }
   end
 
   def client

--- a/app/models/net_suite/connection_form.rb
+++ b/app/models/net_suite/connection_form.rb
@@ -14,7 +14,7 @@ module NetSuite
     end
 
     def allowed_parameters
-      [:account_id, :email, :password]
+      [:account_id, :email, :password, :subsidiary_id]
     end
 
     def update(attributes)

--- a/app/models/net_suite/export.rb
+++ b/app/models/net_suite/export.rb
@@ -1,6 +1,7 @@
 module NetSuite
   class Export
-    def initialize(namely_profiles:, net_suite:)
+    def initialize(configuration:, namely_profiles:, net_suite:)
+      @configuration = configuration
       @namely_profiles = namely_profiles
       @net_suite = net_suite
     end
@@ -18,7 +19,11 @@ module NetSuite
     private
 
     def export(profile)
-      Employee.new(profile, net_suite: @net_suite).export
+      Employee.new(
+        profile,
+        configuration: @configuration,
+        net_suite: @net_suite
+      ).export
     end
 
     class Employee
@@ -28,7 +33,8 @@ module NetSuite
         "Not specified" => "_omitted",
       }
 
-      def initialize(profile, net_suite:)
+      def initialize(profile, configuration:, net_suite:)
+        @configuration = configuration
         @profile = profile
         @net_suite = net_suite
       end
@@ -73,7 +79,7 @@ module NetSuite
           email: @profile.email,
           gender: map_gender(@profile.gender),
           phone: @profile.home_phone,
-          subsidiary: { internalId: 1 },
+          subsidiary: { internalId: @configuration.subsidiary_id },
           title: @profile.job_title[:title]
         }
       end

--- a/app/views/net_suite_connections/edit.html.erb
+++ b/app/views/net_suite_connections/edit.html.erb
@@ -1,0 +1,30 @@
+<%= render "subnav" %>
+
+<section id="subheader">
+  <h1><%= t(".title") %></h2>
+  <p><%= t(".slogan") %></p>
+</section>
+
+<section>
+  <%= simple_form_for(
+    @connection,
+    url: connection_url(:net_suite_connection),
+    html: {class: 'stacked'}
+  ) do |f| %>
+    <%= f.error :base %>
+    <div class="form-row">
+      <%= f.input(
+        :subsidiary_id,
+        as: :select,
+        collection: @connection.subsidiaries,
+        input_html: {class: 'half'}
+      ) %>
+    </div>
+    <div class="-n-actions">
+      <%= button_tag(type: 'submit', class: '-n-btn') do %>
+        <%= fa_icon "plug", text: t("dashboards.show.connect") %>
+      <% end %>
+    </div>
+  <% end %>
+</section>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,7 +148,10 @@ en:
       title: "NetSuite"
       slogan: >
         Please fill out the following fields to connect to this application.
-
+    edit:
+      title: "NetSuite"
+      slogan: >
+        Please fill out the following fields to finalize this connection.
   net_suite_exports:
     create:
       title: "Exporting to NetSuite"

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -25,6 +25,7 @@ en:
         account_id: "Account ID"
         email: "Email"
         password: "Password"
+        subsidiary_id: "Subsidiary"
       namely_authentication:
         subdomain: Subdomain
     placeholders:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,17 @@ Rails.application.routes.draw do
     as: "connection"
   )
 
+  get(
+    "/connections/:form_type/edit",
+    to: "connections#edit",
+    as: "edit_connection"
+  )
+
+  patch(
+    "/connections/:form_type",
+    to: "connections#update"
+  )
+
   delete(
     "/connections/:form_type",
     to: "connections#destroy",

--- a/db/migrate/20150630183442_add_subsidiary_id_to_net_suite_connections.rb
+++ b/db/migrate/20150630183442_add_subsidiary_id_to_net_suite_connections.rb
@@ -1,0 +1,5 @@
+class AddSubsidiaryIdToNetSuiteConnections < ActiveRecord::Migration
+  def change
+    add_column :net_suite_connections, :subsidiary_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150622200851) do
+ActiveRecord::Schema.define(version: 20150630183442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,15 @@ ActiveRecord::Schema.define(version: 20150622200851) do
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+
+  create_table "export_logs", force: true do |t|
+    t.integer  "connection_id",   null: false
+    t.string   "connection_type", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "export_logs", ["connection_id", "connection_type"], name: "index_export_logs_on_connection_id_and_connection_type", using: :btree
 
   create_table "greenhouse_connections", force: true do |t|
     t.datetime "created_at",                         null: false
@@ -75,6 +84,7 @@ ActiveRecord::Schema.define(version: 20150622200851) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "found_namely_field", default: false, null: false
+    t.string   "subsidiary_id"
   end
 
   add_index "net_suite_connections", ["user_id"], name: "index_net_suite_connections_on_user_id", using: :btree

--- a/spec/jobs/net_suite_export_job_spec.rb
+++ b/spec/jobs/net_suite_export_job_spec.rb
@@ -19,7 +19,11 @@ describe NetSuiteExportJob do
       allow(User).to receive(:find).with(user_id).and_return(user)
       allow(NetSuite::Export).
         to receive(:new).
-        with(namely_profiles: all_profiles, net_suite: client).
+        with(
+          configuration: net_suite_connection,
+          namely_profiles: all_profiles,
+          net_suite: client
+        ).
         and_return(export)
       mail = double(SyncMailer, deliver: true)
       allow(SyncMailer).

--- a/spec/models/net_suite/client_spec.rb
+++ b/spec/models/net_suite/client_spec.rb
@@ -212,4 +212,38 @@ describe NetSuite::Client do
       end
     end
   end
+
+  describe "#subsidiaries" do
+    it "looks up subsidiaries" do
+      subsidiaries = [
+        { "internalId" => "1", "name" => "Apple" },
+        { "internalId" => "2", "name" => "Banana" }
+      ]
+      stub_request(
+        :get,
+        "https://api.cloud-elements.com/elements/api-v2" \
+        "/hubs/erp/lookups/subsidiary"
+      ).
+        with(
+          headers: {
+            "Authorization" => "User user-secret, " \
+            "Organization org-secret, " \
+            "Element element-secret",
+            "Content-Type" => "application/json"
+          }
+        ).
+        to_return(status: 200, body: subsidiaries.to_json)
+
+      client = NetSuite::Client.new(
+        user_secret: "user-secret",
+        organization_secret: "org-secret",
+        element_secret: "element-secret"
+      )
+
+      result = client.subsidiaries
+
+      expect(result).to be_success
+      expect(result.to_a).to eq(subsidiaries)
+    end
+  end
 end


### PR DESCRIPTION
Introduces an alternate path for connections where the edit action is
used until the connection has enough feels to be ready.

For NetSuite connections, presents a list of possible subsidiaries and
exports profiles as employees under the selected subsidiary.

https://trello.com/c/uaW9epLf