### PR TITLE
Use conventional Rails routes

### DIFF
--- a/app/controllers/connections_controller.rb
+++ b/app/controllers/connections_controller.rb
@@ -35,37 +35,37 @@ class ConnectionsController < ApplicationController
   def connection_form
     @connection_form ||= ConnectionFormFactory.create(
       connection: connection,
-      form_type: form_type
+      integration_id: params[:integration_id]
     )
   end
 
   def connection
-    @connection ||= current_user.send(form_type)
+    @connection ||= current_user.send(connection_type)
   end
 
   def new_template
-    form_type.pluralize + "/new"
+    connection_type.pluralize + "/new"
   end
 
   def edit_template
-    form_type.pluralize + "/edit"
+    connection_type.pluralize + "/edit"
   end
 
   def after_save_path
     if connection.ready?
       dashboard_path
     else
-      edit_connection_path(form_type)
+      edit_integration_connection_path(params[:integration_id])
     end
   end
 
   def form_params
-    params.require(form_type).permit(
+    params.require(connection_type).permit(
       connection_form.allowed_parameters
     )
   end
 
-  def form_type
-    params[:form_type].to_s
+  def connection_type
+    "#{params[:integration_id]}_connection"
   end
 end

--- a/app/services/connection_form_factory.rb
+++ b/app/services/connection_form_factory.rb
@@ -1,11 +1,11 @@
 class ConnectionFormFactory
-  def self.create(connection:, form_type:)
-    new(connection: connection, form_type: form_type).create_instance
+  def self.create(connection:, integration_id:)
+    new(connection: connection, integration_id: integration_id).create_instance
   end
 
-  def initialize(connection:, form_type:)
+  def initialize(connection:, integration_id:)
     @connection = connection
-    @form_type = form_type
+    @integration_id = integration_id
   end
 
   def create_instance
@@ -17,7 +17,7 @@ class ConnectionFormFactory
   private
 
   def connection_form_class
-    connection_form_class_mapping.fetch(@form_type)
+    connection_form_class_mapping.fetch(@integration_id)
   end
 
   def connection_form_class_arguments
@@ -34,10 +34,10 @@ class ConnectionFormFactory
 
   def connection_form_class_mapping
     {
-      "greenhouse_connection" => Greenhouse::ConnectionForm,
-      "icims_connection" => Icims::ConnectionForm,
-      "jobvite_connection" => Jobvite::ConnectionForm,
-      "net_suite_connection" => NetSuite::ConnectionForm
+      "greenhouse" => Greenhouse::ConnectionForm,
+      "icims" => Icims::ConnectionForm,
+      "jobvite" => Jobvite::ConnectionForm,
+      "net_suite" => NetSuite::ConnectionForm
     }
   end
 end

--- a/app/views/dashboards/_disconnect_button.html.erb
+++ b/app/views/dashboards/_disconnect_button.html.erb
@@ -1,4 +1,4 @@
-<%= button_to path, class: "-n-btn -n-btn-sm -n-btn-danger -n-btn-link", method: :delete, rel: "nofollow" do %>
+<%= button_to integration_connection_path(integration_id), class: "-n-btn -n-btn-sm -n-btn-danger -n-btn-link", method: :delete, rel: "nofollow" do %>
   <%= fa_icon "times" %>
   <%= t("dashboards.show.disconnect") %>
 <% end %>

--- a/app/views/greenhouse_connections/_connection.html.erb
+++ b/app/views/greenhouse_connections/_connection.html.erb
@@ -13,9 +13,9 @@
     <% if connection.found_namely_field? %>
       <%= greenhouse_candidate_imports_url(connection.secret_key) %>
     <% end %>
-    <%= render "disconnect_button", path: destroy_connections_path(:greenhouse_connection) %>
+    <%= render "disconnect_button", integration_id: :greenhouse %>
   <% else %>
-    <%= link_to new_connection_path(:greenhouse_connection), class: "-n-btn -n-btn-sm connect" do %>
+    <%= link_to new_integration_connection_path(:greenhouse), class: "-n-btn -n-btn-sm connect" do %>
       <%= fa_icon "plug", text: t("dashboards.show.connect") %>
     <% end %>
     <h3>

--- a/app/views/greenhouse_connections/new.html.erb
+++ b/app/views/greenhouse_connections/new.html.erb
@@ -8,7 +8,7 @@
 <%= simple_form_for(
   @connection_form,
   as: :greenhouse_connection,
-  url: connection_url(:greenhouse_connection),
+  url: integration_connection_path(:greenhouse),
   html: { class: "stacked" }
 ) do |f| %>
   <div class="form-row">

--- a/app/views/icims_connections/_connection.html.erb
+++ b/app/views/icims_connections/_connection.html.erb
@@ -13,9 +13,9 @@
     <% if connection.found_namely_field? %>
       <%= icims_candidate_imports_url(connection.api_key) %>
     <% end %>
-    <%= render "disconnect_button", path: destroy_connections_path(:icims_connection) %>
+    <%= render "disconnect_button", integration_id: :icims %>
   <% else %>
-    <%= link_to new_connection_path(:icims_connection), class: "-n-btn -n-btn-sm connect" do %>
+    <%= link_to new_integration_connection_path(:icims), class: "-n-btn -n-btn-sm connect" do %>
       <%= fa_icon "plug", text: t("dashboards.show.connect") %>
     <% end %>
     <h3>

--- a/app/views/icims_connections/new.html.erb
+++ b/app/views/icims_connections/new.html.erb
@@ -8,7 +8,7 @@
 <%= simple_form_for(
   @connection_form,
   as: :icims_connection,
-  url: connection_url(:icims_connection),
+  url: integration_connection_path(:icims),
   html: { class: "stacked" }
 ) do |f| %>
   <div class="form-row">

--- a/app/views/jobvite_connections/_connection.html.erb
+++ b/app/views/jobvite_connections/_connection.html.erb
@@ -12,9 +12,9 @@
     <% if connection.found_namely_field? %>
       <%= button_to t("dashboards.show.import_now"), polymorphic_path([connection.namespace, :imports]), class: "-n-btn" %>
     <% end %>
-    <%= render "disconnect_button", path: destroy_connections_path(:jobvite_connection) %>
+    <%= render "disconnect_button", integration_id: :jobvite %>
   <% else %>
-    <%= link_to new_connection_path(:jobvite_connection), class: "-n-btn -n-btn-sm" do %>
+    <%= link_to new_integration_connection_path(:jobvite), class: "-n-btn -n-btn-sm" do %>
       <%= fa_icon "plug", text: t("dashboards.show.connect") %>
     <% end %>
     <h3>

--- a/app/views/jobvite_connections/new.html.erb
+++ b/app/views/jobvite_connections/new.html.erb
@@ -9,7 +9,7 @@
   <%= simple_form_for(
     @connection_form,
     as: :jobvite_connection,
-    url: connection_url(:jobvite_connection),
+    url: integration_connection_path(:jobvite),
     html: { class: "stacked" }
   ) do |f| %>
     <div class="form-row">

--- a/app/views/net_suite_connections/_connection.html.erb
+++ b/app/views/net_suite_connections/_connection.html.erb
@@ -18,9 +18,9 @@
       <% if connection.found_namely_field? %>
         <%= button_to t("dashboards.show.export_now"), polymorphic_path([connection.namespace, :exports]), class: "-n-btn" %>
       <% end %>
-      <%= render "disconnect_button", path: destroy_connections_path(:net_suite_connection) %>
+      <%= render "disconnect_button", integration_id: :net_suite %>
     <% else %>
-      <%= link_to new_connection_path(:net_suite_connection), class: "-n-btn -n-btn-sm" do %>
+      <%= link_to new_integration_connection_path(:net_suite), class: "-n-btn -n-btn-sm" do %>
         <%= fa_icon "plug", text: t("dashboards.show.connect") %>
       <% end %>
       <h3>

--- a/app/views/net_suite_connections/edit.html.erb
+++ b/app/views/net_suite_connections/edit.html.erb
@@ -8,7 +8,7 @@
 <section>
   <%= simple_form_for(
     @connection,
-    url: connection_url(:net_suite_connection),
+    url: integration_connection_path(:net_suite),
     html: {class: 'stacked'}
   ) do |f| %>
     <%= f.error :base %>

--- a/app/views/net_suite_connections/new.html.erb
+++ b/app/views/net_suite_connections/new.html.erb
@@ -9,7 +9,7 @@
   <%= simple_form_for(
     @connection_form,
     as: :net_suite_connection,
-    url: connection_url(:net_suite_connection),
+    url: integration_connection_path(:net_suite),
     html: {class: 'stacked'}
   ) do |f| %>
     <%= f.error :base %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,38 +21,13 @@ Rails.application.routes.draw do
   resources :icims_candidate_retry_imports, only: [:show]
   resource :session, only: [:new, :destroy]
 
+  resources :integrations, only: [] do
+    resource :connection, only: [:new, :create, :edit, :update, :destroy]
+  end
+
   get(
     "/session/oauth_callback",
     to: "sessions#oauth_callback",
     as: "session_oauth_callback"
-  )
-
-  get(
-    "/connections/:form_type/new",
-    to: "connections#new",
-    as: "new_connection"
-  )
-
-  post(
-    "/connections/:form_type",
-    to: "connections#create",
-    as: "connection"
-  )
-
-  get(
-    "/connections/:form_type/edit",
-    to: "connections#edit",
-    as: "edit_connection"
-  )
-
-  patch(
-    "/connections/:form_type",
-    to: "connections#update"
-  )
-
-  delete(
-    "/connections/:form_type",
-    to: "connections#destroy",
-    as: "destroy_connections"
   )
 end

--- a/spec/services/connection_form_factory_spec.rb
+++ b/spec/services/connection_form_factory_spec.rb
@@ -4,28 +4,28 @@ describe ConnectionFormFactory do
   context ".create" do
     context "greenhouse_connection" do
       it "returns a connection form" do
-        connection_form = create_connection_form("greenhouse_connection")
+        connection_form = create_connection_form("greenhouse")
         expect(connection_form.class).to eq(Greenhouse::ConnectionForm)
       end
     end
 
     context "icims_connection" do
       it "returns a connection form" do
-        connection_form = create_connection_form("icims_connection")
+        connection_form = create_connection_form("icims")
         expect(connection_form.class).to eq(Icims::ConnectionForm)
       end
     end
 
     context "jobvite_connection" do
       it "returns a connection form" do
-        connection_form = create_connection_form("jobvite_connection")
+        connection_form = create_connection_form("jobvite")
         expect(connection_form.class).to eq(Jobvite::ConnectionForm)
       end
     end
 
     context "net_suite_connection" do
       it "returns a connection form" do
-        connection_form = create_connection_form("net_suite_connection")
+        connection_form = create_connection_form("net_suite")
         expect(connection_form.class).to eq(NetSuite::ConnectionForm)
       end
     end
@@ -36,21 +36,21 @@ describe ConnectionFormFactory do
         expect do
           ConnectionFormFactory.create(
             connection: connection,
-            form_type: "nonexistant_connection"
+            integration_id: "nonexistant_connection"
           )
         end.to raise_exception(KeyError)
       end
     end
   end
 
-  def create_connection_form(form_type)
+  def create_connection_form(integration_id)
     ConnectionFormFactory.create(
-      connection: create(form_type.to_sym, :connected),
-      form_type: form_type
+      connection: create(:"#{integration_id}_connection", :connected),
+      integration_id: integration_id
     )
   end
 
-  def allow_form_type(form_type)
-    expect { create_connection_form(form_type) }.not_to raise_exception
+  def allow_integration(id:)
+    expect { create_connection_form(id) }.not_to raise_exception
   end
 end


### PR DESCRIPTION
This replaces the custom connection routes with a standard resource.

New URL helpers:

    integration_connection(:net_suite)
    new_integration_connection(:net_suite)
    edit_integration_connection(:net_suite)

New routes:

    POST   /integrations/:integration_id/connection
    GET    /integrations/:integration_id/connection/new
    GET    /integrations/:integration_id/connection/edit
    PATCH  /integrations/:integration_id/connection
    PUT    /integrations/:integration_id/connection
    DELETE /integrations/:integration_id/connection