### PR TITLE
Log an error when an integration can't proceed due to auth issues

### DIFF
--- a/app/models/net_suite/client.rb
+++ b/app/models/net_suite/client.rb
@@ -99,7 +99,6 @@ module NetSuite
     rescue RestClient::BadRequest => exception
       Result.new(false, exception.response)
     rescue RestClient::Unauthorized => exception
-      @user.send_connection_notification("net_suite")
       raise Unauthorized, exception.message
     end
 
@@ -148,8 +147,6 @@ module NetSuite
         @json ||= JSON.parse(@response)
       end
     end
-
-    class Unauthorized < StandardError; end
 
     private_constant :Result
   end

--- a/app/services/greenhouse/candidates_importer.rb
+++ b/app/services/greenhouse/candidates_importer.rb
@@ -55,7 +55,14 @@ module Greenhouse
 
     def raise_unauthorized_error_and_send_notification
       user.send_connection_notification("greenhouse")
-      raise Unauthorized, "Invalid authentication to Greenhouse"
+      exception_class = Greenhouse::CandidatesImporter::Unauthorized
+      error_message = "Invalid authentication for Greenhouse"
+
+      Rails.logger.error(
+        "#{exception_class} error #{error_message} for user_id: #{user.id}"
+      )
+
+      raise Unauthorized, error_message
     end
 
     def user

--- a/app/services/icims/candidate_importer.rb
+++ b/app/services/icims/candidate_importer.rb
@@ -17,8 +17,11 @@ module Icims
       else
         mailer.delay.unsuccessful_import(user, candidate, imported_result)
       end
-    rescue Icims::Client::Error => e
-      mailer.delay.unauthorized_import(user, e.message)
+    rescue Icims::Client::Error => exception
+      mailer.delay.unauthorized_import(user, exception.message)
+      Rails.logger.error(
+        "#{exception.class} error #{exception.message} for user_id: #{user.id}"
+      )
     end
 
     private

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,0 +1,1 @@
+class Unauthorized < StandardError; end

--- a/spec/jobs/sync_job_spec.rb
+++ b/spec/jobs/sync_job_spec.rb
@@ -30,4 +30,34 @@ describe SyncJob do
       expect(mail).to have_received(:deliver)
     end
   end
+
+  context "authentication failure" do
+    it "traps exception and alerts the user" do
+      net_suite_connection = double(NetSuite::Connection)
+      user = double(
+        User,
+        id: 1,
+        email: double(:email),
+        net_suite_connection: net_suite_connection
+      )
+      user_id = double(:user_id)
+      allow(net_suite_connection).to receive(:sync).
+        and_raise(Unauthorized, "An error message")
+      integration_id = "net_suite"
+      allow(User).to receive(:find).with(user_id).and_return(user)
+      allow(user).to receive(:send_connection_notification).with(integration_id)
+      job = SyncJob.new(integration_id, user_id)
+
+      expect(SyncMailer).not_to receive(:net_suite_notification)
+      expect(Rails.logger).to receive(:error).with(
+        "Unauthorized error An error message for user_id: #{user.id} " \
+        "with NetSuite"
+      )
+
+      job.perform
+
+      expect(user).to have_received(:send_connection_notification).
+        with(integration_id)
+    end
+  end
 end

--- a/spec/models/net_suite/client_spec.rb
+++ b/spec/models/net_suite/client_spec.rb
@@ -116,7 +116,7 @@ describe NetSuite::Client do
     end
 
     context "on authentication failure" do
-      it "sends an invalid authentication message" do
+      it "raises an Unauthorized exception" do
         error = "Invalid Organization or User secret, or invalid Element" \
                 " token provided."
 
@@ -134,16 +134,7 @@ describe NetSuite::Client do
           organization_secret: "x"
         )
 
-        mail = double(ConnectionMailer, deliver: true)
-        allow(ConnectionMailer).
-          to receive(:authentication_notification).
-          with(email: user.email, connection_type: "net_suite").
-          and_return(mail)
-
-        expect { client.create_instance({}) }.to raise_error(
-          NetSuite::Client::Unauthorized
-        )
-        expect(mail).to have_received(:deliver)
+        expect { client.create_instance({}) }.to raise_error(Unauthorized)
       end
     end
   end

--- a/spec/services/icims/candidate_importer_spec.rb
+++ b/spec/services/icims/candidate_importer_spec.rb
@@ -1,9 +1,9 @@
-require_relative '../../../app/services/icims/candidate_importer'
+require "rails_helper"
 
 describe Icims::CandidateImporter do
   subject(:service) { described_class.new(connection, mailer, params) }
   let(:connection) { double :connection, user: user }
-  let(:user) { double :user, namely_connection: namely_conn }
+  let(:user) { double :user, id: 1, namely_connection: namely_conn }
   let(:mailer) { double :mailer, delay: delayed }
   let(:namely_conn) { double :namely_conn, profiles: namely_profiles }
   let(:params) { {} }
@@ -47,6 +47,10 @@ describe Icims::CandidateImporter do
         allow_any_instance_of(Icims::Client).
           to(receive(:candidate) { raise Icims::Client::Error.new "Unauthorized"})
 
+        user_id = user.id
+        expect(Rails.logger).to receive(:error).with(
+          "Icims::Client::Error error Unauthorized for user_id: #{user_id}"
+        )
         expect(delayed).to receive(:unauthorized_import).with(user, "Unauthorized")
         service.import
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'active_support/time'
 require_relative '../app/services/users/user_with_full_name'
 require_relative '../app/services/users/access_token_freshener'
 require_relative '../app/services/users/token_expiry'
+require_relative "../lib/exceptions"
 
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
* With SyncJob, this traps the exception
* Icims::CandidatesImporter was trapping the exception, now it logs
* Greenhouse::CandidatesImporter does not trap the exception, which
  was the expected behavior previous to notifying the user
  * Greenhouse::CandidatesImporter will now log the error
* Jobvite does not yet have an implementation that would be affected by
  this
* For: https://trello.com/c/I6f1verE/