### PR TITLE
Extract common authentication notification methods to a module

### DIFF
--- a/app/controllers/greenhouse_candidate_imports_controller.rb
+++ b/app/controllers/greenhouse_candidate_imports_controller.rb
@@ -11,7 +11,7 @@ class GreenhouseCandidateImportsController < ApplicationController
       request.headers['Signature']).import
 
     render nothing: true, status: :ok
-  rescue Greenhouse::CandidatesImporter::Unauthorized
+  rescue Unauthorized
     render nothing: true, status: :unauthorized
   end
 

--- a/app/models/authentication_notifier.rb
+++ b/app/models/authentication_notifier.rb
@@ -1,0 +1,30 @@
+class AuthenticationNotifier
+  def initialize(integration_id:, user:)
+    @integration_id = integration_id
+    @user = user
+  end
+
+  def integration_name
+    I18n.t("#{integration_id}.name")
+  end
+
+  def log_and_notify_of_unauthorized_exception(exception)
+    log_unauthorized_exception(exception)
+    deliver_unauthorized_notification
+  end
+
+  private
+
+  def deliver_unauthorized_notification
+    user.send_connection_notification(integration_id)
+  end
+
+  def log_unauthorized_exception(exception)
+    Rails.logger.error(
+      "#{exception.class} error #{exception.message} for " \
+      "user_id: #{user.id} with #{integration_name}"
+    )
+  end
+
+  attr_reader :integration_id, :user
+end

--- a/app/services/greenhouse/candidates_importer.rb
+++ b/app/services/greenhouse/candidates_importer.rb
@@ -1,8 +1,12 @@
 module Greenhouse
   class CandidatesImporter
-    attr_reader :mailer, :params, :signature, :secret_key, :connection_repo
-
-    class Unauthorized < StandardError; end
+    attr_reader(
+      :connection_repo,
+      :mailer,
+      :params,
+      :secret_key,
+      :signature,
+    )
 
     def initialize(mailer, connection_repo, params, secret_key, signature)
       @params = params
@@ -54,15 +58,17 @@ module Greenhouse
     end
 
     def raise_unauthorized_error_and_send_notification
-      user.send_connection_notification("greenhouse")
-      exception_class = Greenhouse::CandidatesImporter::Unauthorized
-      error_message = "Invalid authentication for Greenhouse"
+      exception = Unauthorized.new(Unauthorized::DEFAULT_MESSAGE)
+      notifier.log_and_notify_of_unauthorized_exception(exception)
 
-      Rails.logger.error(
-        "#{exception_class} error #{error_message} for user_id: #{user.id}"
+      raise exception
+    end
+
+    def notifier
+      AuthenticationNotifier.new(
+        integration_id: "greenhouse",
+        user: user
       )
-
-      raise Unauthorized, error_message
     end
 
     def user

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ Bundler.require(*Rails.groups)
 
 module Connect
   class Application < Rails::Application
+    require_relative "../lib/exceptions"
+
     config.i18n.enforce_available_locales = true
     config.active_record.default_timezone = :utc
 

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,1 +1,3 @@
-class Unauthorized < StandardError; end
+class Unauthorized < StandardError
+  DEFAULT_MESSAGE = "Invalid authentication"
+end

--- a/spec/models/authentication_notifier_spec.rb
+++ b/spec/models/authentication_notifier_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe AuthenticationNotifier do
+  describe "#integration_name" do
+    it "translates to a proper name" do
+      notifier = AuthenticationNotifier.new(
+        integration_id: "icims",
+        user: user_spy
+      )
+
+      expect(notifier.integration_name).to eq("iCIMS")
+    end
+  end
+
+  describe "#log_and_notify_of_unauthorized_exception" do
+    it "logs the exception" do
+      notifier = AuthenticationNotifier.new(
+        integration_id: integration_id_stub,
+        user: user_spy
+      )
+      exception = Unauthorized.new(Unauthorized::DEFAULT_MESSAGE)
+
+      expect(Rails.logger).to receive(:error).with(
+        "#{exception.class} error #{exception.message} for " \
+        "user_id: #{user_spy.id} with #{notifier.integration_name}"
+      )
+
+      notifier.log_and_notify_of_unauthorized_exception(exception)
+    end
+
+    it "tells User to send_connection_notification" do
+      exception = Unauthorized.new(Unauthorized::DEFAULT_MESSAGE)
+      user = user_spy
+
+      AuthenticationNotifier.new(
+        integration_id: integration_id_stub,
+        user: user
+      ).log_and_notify_of_unauthorized_exception(exception)
+
+      expect(user).to have_received(
+        :send_connection_notification
+      ).with(integration_id_stub)
+    end
+  end
+
+  def integration_id_stub
+    "icims"
+  end
+
+  def user_spy
+    instance_spy(User, id: 1)
+  end
+end

--- a/spec/services/greenhouse/candidates_importer_spec.rb
+++ b/spec/services/greenhouse/candidates_importer_spec.rb
@@ -47,7 +47,7 @@ describe Greenhouse::CandidatesImporter do
 
           expect {
             candidates_importer.import
-          }.to raise_error(Greenhouse::CandidatesImporter::Unauthorized)
+          }.to raise_error(Unauthorized)
         end
 
         it "sends an invalid authentication message and logs an error" do
@@ -60,11 +60,11 @@ describe Greenhouse::CandidatesImporter do
             with(email: user.email, connection_type: "greenhouse").
             and_return(mail)
 
-          exception_class = Greenhouse::CandidatesImporter::Unauthorized
-          exception_message = "Invalid authentication for Greenhouse"
+          exception_class = Unauthorized
+          exception_message = "Invalid authentication"
           expect(Rails.logger).to receive(:error).with(
             "#{exception_class} error #{exception_message} for " \
-            "user_id: #{user.id}"
+            "user_id: #{user.id} with Greenhouse"
           )
           expect { candidates_importer.import }.to raise_error(
             exception_class

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ require 'active_support/time'
 require_relative '../app/services/users/user_with_full_name'
 require_relative '../app/services/users/access_token_freshener'
 require_relative '../app/services/users/token_expiry'
-require_relative "../lib/exceptions"
 
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
* Convert Greenhouse::CandidatesImporter to use newly extracted
authentication methods
* Let SyncJob use the common methods as well
* This leaves iCIMS in place for this PR, since that API looks to be
more involved and worth handling in a focused PR
* There's likely a subsequent PR to further align Greenhouse and Icims
candidate importing
* For: https://trello.com/c/NGozb2N4/