### PR TITLE
Refactor authorization notifications across integrations

### DIFF
--- a/app/controllers/jobvite_imports_controller.rb
+++ b/app/controllers/jobvite_imports_controller.rb
@@ -1,7 +1,7 @@
 class JobviteImportsController < ApplicationController
   def create
     @jobvite_imports_presenter = ImportsPresenter.new(importer.import)
-  rescue Jobvite::Client::Unauthorized
+  rescue Unauthorized
     flash[:error] = t("jobvite_connections.authentication_error")
     redirect_to dashboard_path
   end

--- a/app/mailers/connection_mailer.rb
+++ b/app/mailers/connection_mailer.rb
@@ -1,6 +1,7 @@
 class ConnectionMailer < ApplicationMailer
-  def authentication_notification(connection_type:, email:)
+  def authentication_notification(connection_type:, email:, message:)
     @integration = map_connection_type_to_integration(connection_type)
+    @message = message
 
     mail(
       to: email,

--- a/app/mailers/icims_candidate_import_mailer.rb
+++ b/app/mailers/icims_candidate_import_mailer.rb
@@ -24,14 +24,4 @@ class IcimsCandidateImportMailer < ApplicationMailer
       )
     )
   end
-
-  def unauthorized_import(user, error_message)
-    @user = user
-    @error_message = error_message
-
-    mail(
-      to: @user.email,
-      subject: t("icims_candidate_import_mailer.unauthorized_import.subject")
-    )
-  end
 end

--- a/app/models/authentication_notifier.rb
+++ b/app/models/authentication_notifier.rb
@@ -10,13 +10,16 @@ class AuthenticationNotifier
 
   def log_and_notify_of_unauthorized_exception(exception)
     log_unauthorized_exception(exception)
-    deliver_unauthorized_notification
+    deliver_unauthorized_notification(exception)
   end
 
   private
 
-  def deliver_unauthorized_notification
-    user.send_connection_notification(integration_id)
+  def deliver_unauthorized_notification(exception)
+    user.send_connection_notification(
+      connection_type: integration_id,
+      message: exception.message
+    )
   end
 
   def log_unauthorized_exception(exception)

--- a/app/models/icims/authorized_request.rb
+++ b/app/models/icims/authorized_request.rb
@@ -67,8 +67,12 @@ module Icims
       Rails.logger.info("ICIMS request END")
       r.execute
     rescue RestClient::Unauthorized => exception
-      user.send_connection_notification("icims")
-      raise Unauthorized, exception.message
+      unauthorized_exception = Unauthorized.new(exception.message)
+      user.send_connection_notification(
+        connection_type: "icims",
+        message: unauthorized_exception.message
+      )
+      raise unauthorized_exception
     end
 
     private
@@ -112,7 +116,5 @@ module Icims
     def hashed_payload
       digest.hexdigest(payload)
     end
-
-    class Unauthorized < StandardError; end
   end
 end

--- a/app/models/jobvite/client.rb
+++ b/app/models/jobvite/client.rb
@@ -1,7 +1,6 @@
 module Jobvite
   class Client
     class Error < StandardError; end
-    class Unauthorized < StandardError; end
 
     def self.recent_hires(connection)
       new(connection).recent_hires
@@ -80,8 +79,12 @@ module Jobvite
 
       def raise_on_authenticaton_error
         if invalid_secret_key.present?
-          user.send_connection_notification("jobvite")
-          raise Unauthorized, json_response["responseMessage"]
+          exception = Unauthorized.new(json_response["responseMessage"])
+          user.send_connection_notification(
+            connection_type: "jobvite",
+            message: exception.message
+          )
+          raise exception
         end
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,10 +55,11 @@ class User < ActiveRecord::Base
     save
   end
 
-  def send_connection_notification(connection_type)
+  def send_connection_notification(connection_type:, message:)
     ConnectionMailer.authentication_notification(
       connection_type: connection_type,
-      email: email
+      email: email,
+      message: message
     ).deliver
   end
 end

--- a/app/services/icims/candidate_importer.rb
+++ b/app/services/icims/candidate_importer.rb
@@ -18,13 +18,17 @@ module Icims
         mailer.delay.unsuccessful_import(user, candidate, imported_result)
       end
     rescue Icims::Client::Error => exception
-      mailer.delay.unauthorized_import(user, exception.message)
-      Rails.logger.error(
-        "#{exception.class} error #{exception.message} for user_id: #{user.id}"
-      )
+      notifier.log_and_notify_of_unauthorized_exception(exception)
     end
 
     private
+
+    def notifier
+      AuthenticationNotifier.new(
+        integration_id: "icims",
+        user: user
+      )
+    end
 
     def person_id
       params[:personId] || params[:id]

--- a/app/views/connection_mailer/authentication_notification.en.text.erb
+++ b/app/views/connection_mailer/authentication_notification.en.text.erb
@@ -1,3 +1,5 @@
 <%= t(".notice", integration: @integration) -%>
 
+<%= t(".error_message", message: @message) -%>
+
 Namely

--- a/app/views/icims_candidate_import_mailer/unauthorized_import.en.text.erb
+++ b/app/views/icims_candidate_import_mailer/unauthorized_import.en.text.erb
@@ -1,6 +1,0 @@
-iCIMS has reported that you are unauthorized to access this account.
-
-Reason:
-<%= @error_message %>
-
-Please make sure you have the correct permissions and have entered the correct credentials.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,10 @@ en:
 
   connection_mailer:
     authentication_notification:
+      error_message: |
+        You may find the following information about the error helpful:
+
+        %{message}
       notice: |
         Your Namely Connect connection to %{integration} is raising an
         authentication error.
@@ -80,9 +84,6 @@ en:
   icims_candidate_import_mailer:
     successful_import:
       subject: "%{name} successfully added to Namely"
-    unauthorized_import:
-      subject: >
-        You were unable to make this import because you are unauthorized
     unsuccessful_import:
       subject: "Unable to add %{name} to Namely"
 

--- a/spec/mailers/connection_mailer_spec.rb
+++ b/spec/mailers/connection_mailer_spec.rb
@@ -5,9 +5,11 @@ describe ConnectionMailer do
   "describes the problem" do
     connection_type = "icims"
     email = "test@example.com"
+    exception = Unauthorized.new("I can't do that, Dave")
     mailer = ConnectionMailer.authentication_notification(
       connection_type: connection_type,
-      email: email
+      email: email,
+      message: exception.message
     )
 
     expect(mailer.subject).to eq(
@@ -21,6 +23,12 @@ describe ConnectionMailer do
       t(
         "connection_mailer.authentication_notification.notice",
         integration: "iCIMS"
+      )
+    )
+    expect(mailer.body.to_s).to include(
+      t(
+        "connection_mailer.authentication_notification.error_message",
+        message: exception.message
       )
     )
   end

--- a/spec/models/authentication_notifier_spec.rb
+++ b/spec/models/authentication_notifier_spec.rb
@@ -39,7 +39,7 @@ describe AuthenticationNotifier do
 
       expect(user).to have_received(
         :send_connection_notification
-      ).with(integration_id_stub)
+      ).with(connection_type: integration_id_stub, message: exception.message)
     end
   end
 

--- a/spec/models/icims/authorized_request_spec.rb
+++ b/spec/models/icims/authorized_request_spec.rb
@@ -106,14 +106,19 @@ describe Icims::AuthorizedRequest do
         ).to_return(status: 401, body: errors.to_json)
 
         mail = double(ConnectionMailer, deliver: true)
+        exception = Unauthorized.new("401 Unauthorized")
         user = connection.user
         allow(ConnectionMailer).
           to receive(:authentication_notification).
-          with(email: user.email, connection_type: "icims").
+          with(
+            connection_type: "icims",
+            email: user.email,
+            message: exception.message,
+          ).
           and_return(mail)
 
         expect { authorized_request.execute }.to raise_error(
-          Icims::AuthorizedRequest::Unauthorized
+          Unauthorized
         )
         expect(mail).to have_received(:deliver)
       end

--- a/spec/models/jobvite/client_spec.rb
+++ b/spec/models/jobvite/client_spec.rb
@@ -149,7 +149,7 @@ describe Jobvite::Client do
             body: <<-JSON
               {
                 "status":"INVALID_KEY_SECRET",
-                "responseMessage":"an error message"
+                "responseMessage":"An error message"
               }
             JSON
           )
@@ -166,13 +166,18 @@ describe Jobvite::Client do
         client = Jobvite::Client.new(connection)
 
         mail = double(ConnectionMailer, deliver: true)
+        exception = Unauthorized.new("An error message")
         allow(ConnectionMailer).
           to receive(:authentication_notification).
-          with(connection_type: "jobvite", email: user.email).
+          with(
+            connection_type: "jobvite",
+            email: user.email,
+            message: exception.message
+          ).
           and_return(mail)
 
         expect { client.recent_hires }.to raise_error(
-          Jobvite::Client::Unauthorized
+          Unauthorized
         )
         expect(mail).to have_received(:deliver)
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -75,12 +75,20 @@ describe User do
     it "sends an invalid authentication message" do
       user = build_stubbed(:user)
       mail = double(ConnectionMailer, deliver: true)
+      exception = Unauthorized.new("Whoops")
       allow(ConnectionMailer).
         to receive(:authentication_notification).
-        with(email: user.email, connection_type: "icims").
+        with(
+          connection_type: "icims",
+          email: user.email,
+          message: exception.message,
+        ).
         and_return(mail)
 
-      user.send_connection_notification("icims")
+      user.send_connection_notification(
+        connection_type: "icims",
+        message: exception.message
+      )
 
       expect(mail).to have_received(:deliver)
     end

--- a/spec/services/greenhouse/candidates_importer_spec.rb
+++ b/spec/services/greenhouse/candidates_importer_spec.rb
@@ -55,19 +55,22 @@ describe Greenhouse::CandidatesImporter do
             to(receive(:valid?) { false })
 
           mail = double(ConnectionMailer, deliver: true)
+          exception = Unauthorized.new(Unauthorized::DEFAULT_MESSAGE)
           allow(ConnectionMailer).
             to receive(:authentication_notification).
-            with(email: user.email, connection_type: "greenhouse").
+            with(
+              email: user.email,
+              connection_type: "greenhouse",
+              message: exception.message
+            ).
             and_return(mail)
 
-          exception_class = Unauthorized
-          exception_message = "Invalid authentication"
           expect(Rails.logger).to receive(:error).with(
-            "#{exception_class} error #{exception_message} for " \
+            "#{exception.class} error #{exception.message} for " \
             "user_id: #{user.id} with Greenhouse"
           )
           expect { candidates_importer.import }.to raise_error(
-            exception_class
+            exception.class
           )
           expect(mail).to have_received(:deliver)
         end


### PR DESCRIPTION
* The ConnectionMailer now accepts an exception with changes upstream
  to match in User
* IntegrationAuthenticationNotification#set_exception now accepts an
  exception message
* Removed the unauthorized_notification from IcimsCandidateImportMailer
* Icims::CandidateImporter now uses ConnectionMailer to alert to
* authentication/authorization problems
* Icims::CandidateImporter is also using the
  IntegrationAuthenticationNotification module
  * More refactoring to happen here
* For: https://trello.com/c/NGozb2N4/