### PR TITLE
Consolidate translations for page titles

### DIFF
--- a/app/helpers/integration_helper.rb
+++ b/app/helpers/integration_helper.rb
@@ -1,0 +1,5 @@
+module IntegrationHelper
+  def integration_name
+    I18n.t("#{integration_id}.name")
+  end
+end

--- a/app/views/authentications/edit.html.erb
+++ b/app/views/authentications/edit.html.erb
@@ -1,8 +1,8 @@
 <%= render "subnav" %>
 
 <section id="subheader">
-  <h1><%= t("#{integration_id}.authentications.edit.title") %></h2>
-  <p><%= t("#{integration_id}.authentications.edit.slogan") %></p>
+  <h1><%= t(".title", integration: integration_name) %></h2>
+  <p><%= t(".slogan", integration: integration_name) %></p>
 </section>
 
 <%= simple_form_for(

--- a/app/views/authentications/new.html.erb
+++ b/app/views/authentications/new.html.erb
@@ -1,8 +1,8 @@
 <%= render "subnav" %>
 
 <section id="subheader">
-  <h1><%= t("#{integration_id}.authentications.new.title") %></h2>
-  <p><%= t("#{integration_id}.authentications.new.slogan") %></p>
+  <h1><%= t(".title", integration: integration_name) %></h2>
+  <p><%= t(".slogan", integration: integration_name) %></p>
 </section>
 
 <%= simple_form_for(

--- a/app/views/connections/edit.html.erb
+++ b/app/views/connections/edit.html.erb
@@ -1,8 +1,8 @@
 <%= render "subnav" %>
 
 <section id="subheader">
-  <h1><%= t("#{integration_id}.connections.edit.title") %></h2>
-  <p><%= t("#{integration_id}.connections.edit.slogan") %></p>
+  <h1><%= t(".title", integration: integration_name) %></h2>
+  <p><%= t(".slogan", integration: integration_name) %></p>
 </section>
 
 <%= simple_form_for(

--- a/app/views/syncs/create.html.erb
+++ b/app/views/syncs/create.html.erb
@@ -1,4 +1,4 @@
 <section id="subheader">
-  <h1><%= t("#{@connection.integration_id}.syncs.create.title") %></h2>
-  <p><%= t("#{@connection.integration_id}.syncs.create.slogan") %></p>
+  <h1><%= t(".title", integration: integration_name) %></h2>
+  <p><%= t(".slogan", integration: integration_name) %></p>
 </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,64 +148,38 @@ en:
       connected_html: Connected NetSuite Description
       disconnected_html: Disconnected NetSuite Description
 
+  authentications:
+    new:
+      title: "Connect to %{integration}"
+      slogan: >
+        Please fill out the following fields to connect to this application.
+    edit:
+      title: "Update credentials for %{integration}"
+      slogan: >
+        Please fill out the following fields to update your credentials.
+
+  connections:
+    edit:
+      title: "Connect to %{integration}"
+      slogan: >
+        Please fill out the following fields to finalize this connection.
+  syncs:
+    create:
+      title: "Synchronizing with %{integration}"
+      slogan: >
+        We are synchronizing your profiles with %{integration} and will send you
+        an email as soon as synchronization is complete.
+
   greenhouse:
     name: Greenhouse
-    authentications:
-      new:
-        title: "Greenhouse"
-        slogan: >
-          Please fill out the following fields to connect to this application.
-      edit:
-        title: "Greenhouse"
-        slogan: >
-          Please fill out the following fields to update your credentials.
-
   icims:
     name: iCIMS
-    authentications:
-      new:
-        title: "iCIMS"
-        slogan: >
-          Please fill out the following fields to connect to this application.
-      edit:
-        title: "iCIMS"
-        slogan: >
-          Please fill out the following fields to update your credentials.
 
   jobvite:
     name: Jobvite
-    authentications:
-      new:
-        title: "Jobvite"
-        slogan: >
-          Please fill out the following fields to connect to this application.
-      edit:
-        title: "Jobvite"
-        slogan: >
-          Please fill out the following fields to update your credentials.
 
   net_suite:
     name: NetSuite
-    authentications:
-      new:
-        title: "NetSuite"
-        slogan: >
-          Please fill out the following fields to connect to this application.
-      edit:
-        title: "NetSuite"
-        slogan: >
-          Please fill out the following fields to update your credentials.
-    connections:
-      edit:
-        title: "NetSuite"
-        slogan: >
-          Please fill out the following fields to finalize this connection.
-    syncs:
-      create:
-        title: "Exporting to NetSuite"
-        slogan: >
-          We are exporting your profiles to NetSuite and will send you an email
-          as soon as the export is complete.
 
   status:
     client_error: "Service error: %{message}"

--- a/spec/features/user_exports_to_net_suite_spec.rb
+++ b/spec/features/user_exports_to_net_suite_spec.rb
@@ -29,7 +29,8 @@ feature "user exports to net suite" do
 
     find(".net-suite-account").click_on t("dashboards.show.export_now")
 
-    expect(page).to have_content(t("net_suite.syncs.create.title"))
+    expect(page).
+      to have_content(t("syncs.create.title", integration: t("net_suite.name")))
 
     open_email user.email
     expect(current_email).to have_text(


### PR DESCRIPTION
We were repeating the same headings for each integration. This
consolidates the headings into a single key for each page, reducing
noise in pull requests and reducing the number of steps required to add
a new integration.