### PR TITLE
First pass at AttributeMapper and FieldMapping objects

### DIFF
--- a/app/models/attribute_mapper.rb
+++ b/app/models/attribute_mapper.rb
@@ -1,0 +1,19 @@
+class AttributeMapper < ActiveRecord::Base
+  belongs_to :user, dependent: :destroy
+  has_many :field_mappings
+
+  validates :mapping_direction, presence: true
+  validates :user, presence: true
+  validates :user_id, presence: true
+
+  enum mapping_direction: { import: 0, export: 1 }
+
+  def build_field_mappings(default_field_mapping)
+    default_field_mapping.each_pair do |namely_field, integration_field|
+      field_mappings << FieldMapping.new(
+        integration_field_name: integration_field.to_s,
+        namely_field_name: namely_field
+      )
+    end
+  end
+end

--- a/app/models/field_mapping.rb
+++ b/app/models/field_mapping.rb
@@ -1,0 +1,8 @@
+class FieldMapping < ActiveRecord::Base
+  belongs_to :attribute_mapper, dependent: :destroy
+
+  validates :attribute_mapper, presence: true
+  validates :attribute_mapper_id, presence: true
+  validates :integration_field_name, presence: true
+  validates :namely_field_name, presence: true
+end

--- a/app/models/net_suite/attribute_mapper_builder.rb
+++ b/app/models/net_suite/attribute_mapper_builder.rb
@@ -1,0 +1,32 @@
+class NetSuite::AttributeMapperBuilder
+  def initialize(user:)
+    @attribute_mapper = AttributeMapper.new(
+      mapping_direction: :export,
+      user: user
+    )
+  end
+
+  def build
+    attribute_mapper.save
+    build_field_mappings
+    attribute_mapper
+  end
+
+  def default_field_mapping
+    {
+      "email" => "email",
+      "first_name" => "firstName",
+      "gender" => "gender",
+      "last_name" => "lastName",
+      "home_phone" => "phone",
+    }
+  end
+
+  private
+
+  def build_field_mappings
+    attribute_mapper.build_field_mappings(default_field_mapping)
+  end
+
+  attr_accessor :attribute_mapper
+end

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -1,7 +1,10 @@
 class NetSuite::Connection < ActiveRecord::Base
-  belongs_to :user
+  belongs_to :attribute_mapper, dependent: :destroy
+  belongs_to :user, dependent: :destroy
 
   validates :subsidiary_id, presence: true, allow_nil: true
+
+  after_create :build_attribute_mapper
 
   def integration_id
     :net_suite
@@ -47,5 +50,13 @@ class NetSuite::Connection < ActiveRecord::Base
 
   def disconnect
     update!(instance_id: nil, authorization: nil)
+  end
+
+  private
+
+  def build_attribute_mapper
+    builder = NetSuite::AttributeMapperBuilder.new(user: user)
+    self.attribute_mapper = builder.build
+    save
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ActiveRecord::Base
   has_one :icims_connection, class_name: "Icims::Connection"
   has_one :greenhouse_connection, class_name: "Greenhouse::Connection"
   has_one :net_suite_connection, class_name: "NetSuite::Connection"
+  has_many :attribute_mappers
 
   def self.ready_to_sync_with(integration)
     association = "#{integration}_connection"

--- a/db/migrate/20150715184131_create_attribute_mappers.rb
+++ b/db/migrate/20150715184131_create_attribute_mappers.rb
@@ -1,0 +1,10 @@
+class CreateAttributeMappers < ActiveRecord::Migration
+  def change
+    create_table :attribute_mappers do |t|
+      t.integer :mapping_direction, default: 0, null: false
+      t.references :user, foreign_key: true, index: true, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150720151900_create_field_mappings.rb
+++ b/db/migrate/20150720151900_create_field_mappings.rb
@@ -1,0 +1,16 @@
+class CreateFieldMappings < ActiveRecord::Migration
+  def change
+    create_table :field_mappings do |t|
+      t.string :integration_field_name, null: false
+      t.string :namely_field_name, null: false
+      t.references(
+        :attribute_mapper,
+        foreign_key: true,
+        index: true,
+        null: false,
+      )
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150720171724_add_attribute_mapper_ref_to_net_suite_connections.rb
+++ b/db/migrate/20150720171724_add_attribute_mapper_ref_to_net_suite_connections.rb
@@ -1,0 +1,10 @@
+class AddAttributeMapperRefToNetSuiteConnections < ActiveRecord::Migration
+  def change
+    add_reference(
+      :net_suite_connections,
+      :attribute_mapper,
+      foreign_key: true,
+      index: true
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150630183442) do
+ActiveRecord::Schema.define(version: 20150720171724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "attribute_mappers", force: true do |t|
+    t.integer  "mapping_direction", default: 0, null: false
+    t.integer  "user_id",                       null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+  end
+
+  add_index "attribute_mappers", ["user_id"], name: "index_attribute_mappers_on_user_id", using: :btree
 
   create_table "delayed_jobs", force: true do |t|
     t.integer  "priority",   default: 0, null: false
@@ -32,14 +41,15 @@ ActiveRecord::Schema.define(version: 20150630183442) do
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
-  create_table "export_logs", force: true do |t|
-    t.integer  "connection_id",   null: false
-    t.string   "connection_type", null: false
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+  create_table "field_mappings", force: true do |t|
+    t.string   "integration_field_name", null: false
+    t.string   "namely_field_name",      null: false
+    t.integer  "attribute_mapper_id",    null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
-  add_index "export_logs", ["connection_id", "connection_type"], name: "index_export_logs_on_connection_id_and_connection_type", using: :btree
+  add_index "field_mappings", ["attribute_mapper_id"], name: "index_field_mappings_on_attribute_mapper_id", using: :btree
 
   create_table "greenhouse_connections", force: true do |t|
     t.datetime "created_at",                         null: false
@@ -83,10 +93,12 @@ ActiveRecord::Schema.define(version: 20150630183442) do
     t.string   "authorization"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "found_namely_field", default: false, null: false
+    t.boolean  "found_namely_field",  default: false, null: false
     t.string   "subsidiary_id"
+    t.integer  "attribute_mapper_id"
   end
 
+  add_index "net_suite_connections", ["attribute_mapper_id"], name: "index_net_suite_connections_on_attribute_mapper_id", using: :btree
   add_index "net_suite_connections", ["user_id"], name: "index_net_suite_connections_on_user_id", using: :btree
 
   create_table "users", force: true do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,15 @@
 FactoryGirl.define do
+  factory :attribute_mapper do
+    mapping_direction :export
+    user
+  end
+
+  factory :field_mapping do
+    attribute_mapper
+    integration_field_name "firstName"
+    namely_field_name "first_name"
+  end
+
   factory :net_suite_connection, :class => 'NetSuite::Connection' do
     user
 

--- a/spec/models/attribute_mapper_spec.rb
+++ b/spec/models/attribute_mapper_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+describe AttributeMapper do
+  describe "validations" do
+    it { should validate_presence_of(:mapping_direction) }
+    it { should validate_presence_of(:user) }
+  end
+
+  describe "associations" do
+    it { should belong_to(:user).dependent(:destroy) }
+    it { should have_many(:field_mappings) }
+  end
+
+  describe "#build_field_mappings" do
+    let(:attribute_mapper) do
+      AttributeMapper.new(
+        mapping_direction: :import,
+        user: create(:user)
+      )
+    end
+
+    let(:default_field_mapping) do
+      {
+        "email" => "email",
+        "first_name" => "firstName",
+        "gender" => "gender",
+        "home_phone" => "phone",
+        "last_name" => "lastName",
+      }
+    end
+
+    it "has a FieldMapping for each default field" do
+      attribute_mapper.save
+      attribute_mapper.build_field_mappings(default_field_mapping)
+
+      integration_mappings = attribute_mapper.field_mappings.map(
+        &:integration_field_name
+      )
+      namely_mappings = attribute_mapper.field_mappings.map(
+        &:namely_field_name
+      )
+
+      expect(integration_mappings).to match_array(default_field_mapping.values)
+      expect(namely_mappings).to match_array(default_field_mapping.keys)
+    end
+
+    it "persists the FieldMappings" do
+      attribute_mapper.save
+      attribute_mapper.build_field_mappings(default_field_mapping)
+
+      expect(
+        attribute_mapper.field_mappings.reject(&:persisted?)
+      ).to be_empty
+    end
+  end
+end

--- a/spec/models/field_mapping_spec.rb
+++ b/spec/models/field_mapping_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe FieldMapping do
+  describe "validations" do
+    it { should validate_presence_of(:integration_field_name) }
+    it { should validate_presence_of(:namely_field_name) }
+    it { should validate_presence_of(:attribute_mapper) }
+  end
+
+  describe "associations" do
+    it { should belong_to(:attribute_mapper).dependent(:destroy) }
+  end
+end

--- a/spec/models/net_suite/attribute_mapper_builder_spec.rb
+++ b/spec/models/net_suite/attribute_mapper_builder_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe NetSuite::AttributeMapperBuilder do
+  let(:builder) do
+    NetSuite::AttributeMapperBuilder.new(user: create(:user))
+  end
+
+  describe "AttributeMapper" do
+    it "returns an AttributeMapper" do
+      attribute_mapper = builder.build
+
+      expect(attribute_mapper).to be_an_instance_of(AttributeMapper)
+    end
+
+    it "persists the AttributeMapper" do
+      attribute_mapper = builder.build
+
+      expect(attribute_mapper).to be_persisted
+    end
+  end
+
+  describe "#build_field_mappings" do
+    it "has a FieldMapping for each default field" do
+      attribute_mapper = builder.build
+
+      integration_mappings = attribute_mapper.field_mappings.map(
+        &:integration_field_name
+      )
+      namely_mappings = attribute_mapper.field_mappings.map(
+        &:namely_field_name
+      )
+
+      expect(integration_mappings).to match_array(
+        builder.default_field_mapping.values
+      )
+      expect(namely_mappings).to match_array(
+        builder.default_field_mapping.keys
+      )
+    end
+  end
+end

--- a/spec/models/net_suite/connection_spec.rb
+++ b/spec/models/net_suite/connection_spec.rb
@@ -6,6 +6,11 @@ describe NetSuite::Connection do
     it { is_expected.not_to allow_value("").for(:subsidiary_id) }
   end
 
+  describe "associations" do
+    it { should belong_to(:attribute_mapper).dependent(:destroy) }
+    it { should belong_to(:user).dependent(:destroy) }
+  end
+
   describe "#connected?" do
     context "with saved authorization data" do
       it "returns true" do
@@ -53,6 +58,22 @@ describe NetSuite::Connection do
       it "returns false" do
         expect(NetSuite::Connection.new(subsidiary_id: nil)).not_to be_ready
       end
+    end
+  end
+
+  describe "#attribute_mapper" do
+    it "returns the AttributeMapper built from an `after_create` hook" do
+      connection = NetSuite::Connection.new(
+        subsidiary_id: "x",
+        user: create(:user)
+      )
+
+      expect(connection.attribute_mapper).to be_nil
+
+      connection.save
+
+      expect(connection.attribute_mapper).to be_an_instance_of AttributeMapper
+      expect(connection.attribute_mapper).to be_persisted
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,9 +2,11 @@ require "rails_helper"
 
 describe User do
   describe "associations" do
+    it { should have_one(:greenhouse_connection) }
     it { should have_one(:jobvite_connection) }
     it { should have_one(:icims_connection) }
     it { should have_one(:net_suite_connection) }
+    it { should have_many(:attribute_mappers) }
   end
 
   describe "#jobvite_connection" do


### PR DESCRIPTION
* AttributeMapper belongs to a User, primarily so if a User goes away, the
  AttributeMapper will, too
* AttributeMappers will be created per connection. AttributeMappers have_a
  connection, Connections belong_to an AttributeMapper
  * This is in order to avoid needing a polymorphic relationship on
    AttributeMapper
* NB: Not yet wired into NetSuite::Export
* NB: Does not yet handle fields that need any sort of additional handling

Following a recommendation from Mike Burns to not create this implicitly by
calling `#attribute_mapper`, particularly when a GET request uses
NetSuite::Connection, it may have database side-effects, which violates the
Principle of Least Surprise.

We're not thrilled with having it in an `after_create` here, but we like it
better than it being implicit.

* For: https://trello.com/c/JsdID6YF/