### PR TITLE
NetSuite::AttributeMapper can provide export-ready attributes

### DIFF
--- a/app/models/attribute_mapper.rb
+++ b/app/models/attribute_mapper.rb
@@ -2,11 +2,8 @@ class AttributeMapper < ActiveRecord::Base
   belongs_to :user, dependent: :destroy
   has_many :field_mappings
 
-  validates :mapping_direction, presence: true
   validates :user, presence: true
   validates :user_id, presence: true
-
-  enum mapping_direction: { import: 0, export: 1 }
 
   def build_field_mappings(default_field_mapping)
     default_field_mapping.each_pair do |namely_field, integration_field|
@@ -17,19 +14,13 @@ class AttributeMapper < ActiveRecord::Base
     end
   end
 
-  def call(profile)
-    send(mapping_direction, profile)
-  end
-
-  private
-
   def export(profile)
     field_mappings.each_with_object({}) do |field_mapping, accumulator|
-      if profile[field_mapping.namely_field_name].present?
+      if profile.send(field_mapping.namely_field_name).present?
         accumulator.merge!(
-          field_mapping.integration_field_name => profile[
+          field_mapping.integration_field_name => profile.send(
             field_mapping.namely_field_name
-          ]
+          )
         )
       end
     end

--- a/app/models/net_suite/attribute_mapper.rb
+++ b/app/models/net_suite/attribute_mapper.rb
@@ -1,14 +1,46 @@
 class NetSuite::AttributeMapper
-  delegate :call, to: :attribute_mapper
+  GENDER_MAP = {
+    "Male" => "_male",
+    "Female" => "_female",
+    "Not specified" => "_omitted",
+  }
+  GENDER_MAP.default = "_omitted"
+
   delegate :field_mappings, to: :attribute_mapper
   delegate :mapping_direction, to: :attribute_mapper
+  delegate :persisted?, to: :attribute_mapper
 
   def initialize(attribute_mapper:, configuration:)
     @attribute_mapper = attribute_mapper
     @configuration = configuration
   end
 
+  def export(profile)
+    attribute_mapper.export(profile)
+  end
+
+  def post_handle(exported_profile)
+    exported_profile["gender"] = map_gender(exported_profile["gender"])
+    exported_profile["subsidiary"] = set_subsidiary_id
+    exported_profile["title"] = format_job_title(exported_profile["title"])
+
+    exported_profile
+  end
+
   private
+
+  def format_job_title(value)
+    value = Hash(value)
+    value.fetch(:title) { "" }
+  end
+
+  def map_gender(value)
+    GENDER_MAP[value]
+  end
+
+  def set_subsidiary_id
+    { "internalId" => configuration.subsidiary_id }
+  end
 
   attr_reader :attribute_mapper, :configuration
 end

--- a/app/models/net_suite/attribute_mapper_builder.rb
+++ b/app/models/net_suite/attribute_mapper_builder.rb
@@ -1,9 +1,6 @@
 class NetSuite::AttributeMapperBuilder
   def initialize(user:)
-    @attribute_mapper = ::AttributeMapper.new(
-      mapping_direction: :export,
-      user: user
-    )
+    @attribute_mapper = ::AttributeMapper.new(user: user)
   end
 
   def build
@@ -17,8 +14,9 @@ class NetSuite::AttributeMapperBuilder
       "email" => "email",
       "first_name" => "firstName",
       "gender" => "gender",
-      "last_name" => "lastName",
       "home_phone" => "phone",
+      "job_title" => "title",
+      "last_name" => "lastName",
     }
   end
 

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -6,6 +6,16 @@ class NetSuite::Connection < ActiveRecord::Base
 
   after_create :build_attribute_mapper
 
+  delegate :export, to: :attribute_mapper
+  delegate :post_handle, to: :attribute_mapper
+
+  def attribute_mapper
+    @attribute_mapper ||= NetSuite::AttributeMapper.new(
+      attribute_mapper: super,
+      configuration: self
+    )
+  end
+
   def integration_id
     :net_suite
   end

--- a/db/migrate/20150727184245_adjust_attribute_mapper_drop_mapping_direction.rb
+++ b/db/migrate/20150727184245_adjust_attribute_mapper_drop_mapping_direction.rb
@@ -1,0 +1,15 @@
+class AdjustAttributeMapperDropMappingDirection < ActiveRecord::Migration
+  def up
+    remove_column :attribute_mappers, :mapping_direction
+  end
+
+  def down
+    add_column(
+      :attribute_mappers,
+      :mapping_direction,
+      :integer,
+      default: 0,
+      null: false
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,16 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150720171724) do
+ActiveRecord::Schema.define(version: 20150727184245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "attribute_mappers", force: true do |t|
-    t.integer  "mapping_direction", default: 0, null: false
-    t.integer  "user_id",                       null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.integer  "user_id",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "attribute_mappers", ["user_id"], name: "index_attribute_mappers_on_user_id", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :attribute_mapper do
-    mapping_direction :export
     user
   end
 

--- a/spec/models/attribute_mapper_spec.rb
+++ b/spec/models/attribute_mapper_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 describe AttributeMapper do
   describe "validations" do
-    it { should validate_presence_of(:mapping_direction) }
     it { should validate_presence_of(:user) }
   end
 
@@ -14,7 +13,6 @@ describe AttributeMapper do
   describe "#build_field_mappings" do
     let(:attribute_mapper) do
       AttributeMapper.new(
-        mapping_direction: :import,
         user: create(:user)
       )
     end

--- a/spec/models/net_suite/connection_spec.rb
+++ b/spec/models/net_suite/connection_spec.rb
@@ -68,11 +68,11 @@ describe NetSuite::Connection do
         user: create(:user)
       )
 
-      expect(connection.attribute_mapper).to be_nil
-
       connection.save
 
-      expect(connection.attribute_mapper).to be_an_instance_of AttributeMapper
+      expect(connection.attribute_mapper).to be_an_instance_of(
+        NetSuite::AttributeMapper
+      )
       expect(connection.attribute_mapper).to be_persisted
     end
   end
@@ -137,6 +137,18 @@ describe NetSuite::Connection do
       connection.sync
 
       expect(export).to have_received(:perform)
+    end
+  end
+
+  describe "#export" do
+    it { should delegate_method(:export).to(:attribute_mapper).as(:export) }
+  end
+
+  describe "#post_handle" do
+    it do
+      should delegate_method(
+        :post_handle
+      ).to(:attribute_mapper).as(:post_handle)
     end
   end
 


### PR DESCRIPTION
* NetSuite::AttributeMapper will be passed as context to
  ::AttributeMapper
* NetSuite::AttributeMapper defines a hash in `#post_mapping_handlers`
  * These will convert a matching value in the transformed profile to
    what will be expected at NetSuite
  * I didn't implement this as an `inject` since I'm not always
    expecting to have a value in the transformed profile, but I want to
    ensure one exists after post handling
* This will need to be hooked into
  `NetSuite::Export::Employee#attributes`
* This will replace handling in NetSuite::Export for mapping gender,
  handling the job title data structure and setting the subsidiary id
* For: https://trello.com/c/at7jXc36/