### PR TITLE
Install specific version of bundler in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:2.2.2
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev qt5-default libqt5webkit5-dev xvfb
 RUN mkdir /connect
 WORKDIR /connect
+RUN gem install bundler -v "~> 1.10.0"
 ADD Gemfile /connect/Gemfile
 ADD Gemfile.lock /connect/Gemfile.lock
 RUN bundle install


### PR DESCRIPTION
Because:

* Newer versions of bundler add "BUNDLED_WITH"
* Older versions will remove it

This commit:

* Adds a specific, newer version of bundler
* "BUNDLED_WITH" will no longer change between machines