### PR TITLE
Include custom Namely fields in possible mappings

### DIFF
--- a/app/models/attribute_mapper.rb
+++ b/app/models/attribute_mapper.rb
@@ -1,4 +1,14 @@
 class AttributeMapper < ActiveRecord::Base
+  SUPPORTED_TYPES = %w(
+    email
+    longtext
+    referencehistory
+    referenceselect
+    select
+    text
+  )
+  # Unsupported: address checkboxes date file image salary
+
   belongs_to :user, dependent: :destroy
   has_many :field_mappings
 
@@ -7,49 +17,6 @@ class AttributeMapper < ActiveRecord::Base
 
   accepts_nested_attributes_for :field_mappings
 
-  NAMELY_FIELDS = [
-    :asset_management,
-    :bio,
-    :corporate_card_number,
-    :current_job_description,
-    :dental_info,
-    :departure_date,
-    :dob,
-    :email,
-    :emergency_contact,
-    :emergency_contact_phone,
-    :employee_handbook,
-    :employee_id,
-    :employee_wage_theft_prevention_act,
-    :first_name,
-    :gender,
-    :healthcare_info,
-    :home_phone,
-    :image,
-    :job_change_reason,
-    :job_description,
-    :job_title,
-    :key_tag_number,
-    :laptop_asset_number,
-    :last_name,
-    :life_insurance_info,
-    :linkedin_url,
-    :marital_status,
-    :middle_name,
-    :mobile_phone,
-    :office_company_mobile,
-    :office_direct_dial,
-    :office_fax,
-    :office_main_number,
-    :office_phone,
-    :personal_email,
-    :preferred_name,
-    :resume,
-    :start_date,
-    :test_custom_field,
-    :user_status,
-    :vision_plan_info,
-  ]
 
   def build_field_mappings(default_field_mapping)
     default_field_mapping.each_pair do |namely_field, integration_field|
@@ -70,5 +37,13 @@ class AttributeMapper < ActiveRecord::Base
         )
       end
     end
+  end
+
+  def namely_fields
+    user.
+      namely_fields.
+      all.
+      select { |field| SUPPORTED_TYPES.include?(field.type) }.
+      map { |field| [field.label, field.name] }
   end
 end

--- a/app/views/mappings/_field_mapping.html.erb
+++ b/app/views/mappings/_field_mapping.html.erb
@@ -8,8 +8,7 @@
   <td>
     <%= fields.input(
       :namely_field_name,
-      collection: ::AttributeMapper::NAMELY_FIELDS.map(&:to_s),
-      label_method: :humanize,
+      collection: namely_fields,
       label: false
     ) %>
   </td>

--- a/app/views/mappings/edit.html.erb
+++ b/app/views/mappings/edit.html.erb
@@ -12,8 +12,9 @@
       <%= form.simple_fields_for(:field_mappings) do |fields| %>
         <%= render(
           "field_mapping",
+          field_mapping: fields.object,
           fields: fields,
-          field_mapping: fields.object
+          namely_fields: @attribute_mapper.namely_fields
         ) %>
       <% end %>
     </tbody>

--- a/spec/features/user_exports_to_net_suite_spec.rb
+++ b/spec/features/user_exports_to_net_suite_spec.rb
@@ -38,6 +38,7 @@ feature "user exports to net suite" do
     click_button t("helpers.submit.net_suite_connection.update")
 
     select "Mobile phone", from: t("integration_fields.phone")
+    select "Custom field", from: t("integration_fields.email")
     click_on t("attribute_mappings.edit.save")
 
     find(".net-suite-account").click_on t("dashboards.show.export_now")
@@ -63,6 +64,12 @@ feature "user exports to net suite" do
     )
     expect(WebMock).
       to have_requested(:post, "#{cloud_elements}/employees").
-      with(body: hash_including(phone: "+46 70 818 12 34", title: "CEO"))
+      with(
+        body: hash_including(
+          email: "sally.secondary@example.com",
+          phone: "+46 70 818 12 34",
+          title: "CEO",
+        )
+      )
   end
 end

--- a/spec/fixtures/api_responses/fields_with_net_suite.json
+++ b/spec/fixtures/api_responses/fields_with_net_suite.json
@@ -483,6 +483,17 @@
       "links": {
         "section": "afe67e3d-7648-4df9-8436-7cc0538c8644"
       }
+    },
+    {
+      "id": "8bf5dfba-90cb-46bd-9170-1b5773087118",
+      "name": "custom_field",
+      "label": "Custom field",
+      "type": "text",
+      "default": false,
+      "valid_format_info": "generic text",
+      "links": {
+        "section": "347f2936-353a-11e5-a151-feff819cdc9f"
+      }
     }
   ]
 }

--- a/spec/fixtures/api_responses/profiles_with_net_suite_fields.json
+++ b/spec/fixtures/api_responses/profiles_with_net_suite_fields.json
@@ -12,7 +12,8 @@
       {
         "id":"0c601728-2658-4677-a22b-1c8653b431ae",
         "title":"CEO"
-      }
+      },
+      "custom_field":"sally.secondary@example.com"
     },
     {
       "id":"a759ba38-1522-443a-bdae-435d721eb316",
@@ -25,7 +26,8 @@
       {
         "id":"7ac05eec-4b6a-4ec6-bd08-f1c1572815c6",
         "title":"COO"
-      }
+      },
+      "custom_field":"secondary@example.com"
     },
     {
       "id":"3f51b510-1922-11e5-b939-0800200c9a66",
@@ -39,7 +41,8 @@
         "id":"",
         "title":"CTO"
       },
-      "netsuite_id":"1234"
+      "netsuite_id":"1234",
+      "custom_field":"secondary@example.com"
     }
   ]
 }

--- a/spec/models/attribute_mapper_spec.rb
+++ b/spec/models/attribute_mapper_spec.rb
@@ -51,4 +51,43 @@ describe AttributeMapper do
       ).to be_empty
     end
   end
+
+  describe "#namely_fields" do
+    it "returns mappable fields from a Namely connection" do
+      ["single_select", "short_text", "long_text", "number"]
+      models = [
+        double(name: "first_name", label: "First name", type: "text"),
+        double(name: "last_name", label: "Last name", type: "longtext"),
+        double(name: "gender", label: "Gender", type: "select"),
+        double(name: "email", label: "Email", type: "email"),
+        double(name: "job_title", label: "Job title", type: "referencehistory"),
+        double(name: "user_status", label: "Status", type: "referenceselect"),
+        stub_profile_field(type: "address"),
+        stub_profile_field(type: "checkboxes"),
+        stub_profile_field(type: "date"),
+        stub_profile_field(type: "file"),
+        stub_profile_field(type: "image"),
+        stub_profile_field(type: "salary"),
+      ]
+      fields = double("fields", all: models)
+      user = build_stubbed(:user)
+      allow(user).to receive(:namely_fields).and_return(fields)
+      attribute_mapper = AttributeMapper.new(user: user)
+
+      result = attribute_mapper.namely_fields
+
+      expect(result).to eq([
+        ["First name", "first_name"],
+        ["Last name", "last_name"],
+        ["Gender", "gender"],
+        ["Email", "email"],
+        ["Job title", "job_title"],
+        ["Status", "user_status"]
+      ])
+    end
+
+    def stub_profile_field(type:)
+      double(name: type, label: "#{type} field", type: type)
+    end
+  end
 end


### PR DESCRIPTION
Because:

* Many NetSuite fields do not have a corresponding field in Namely
* Users will create custom Namely fields to capture these values

This commit:

* Uses the Namely API to discover possible fields
* Includes custom fields in the list of mappable fields

https://trello.com/c/rgC5mN3g