### PR TITLE
Create a Profile object, wrap Namely Profiles in Profile

### DIFF
--- a/app/models/attribute_mapper.rb
+++ b/app/models/attribute_mapper.rb
@@ -29,12 +29,9 @@ class AttributeMapper < ActiveRecord::Base
 
   def export(profile)
     field_mappings.each_with_object({}) do |field_mapping, accumulator|
-      if profile.send(field_mapping.namely_field_name).present?
-        accumulator.merge!(
-          field_mapping.integration_field_name => profile.send(
-            field_mapping.namely_field_name
-          )
-        )
+      value = profile[field_mapping.namely_field_name]
+      if value.present?
+        accumulator.merge!(field_mapping.integration_field_name => value)
       end
     end
   end

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -49,7 +49,7 @@ class NetSuite::Connection < ActiveRecord::Base
   def sync
     NetSuite::Export.new(
       attribute_mapper: net_suite_attribute_mapper,
-      namely_profiles: user.namely_profiles.all,
+      namely_profiles: user.namely_profiles,
       net_suite: client
     ).perform
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,16 @@
+class Profile
+  delegate :[], to: :namely_profile
+  delegate :update, to: :namely_profile
+
+  def initialize(namely_profile)
+    @namely_profile = namely_profile
+  end
+
+  def name
+    "#{namely_profile[:first_name]} #{namely_profile[:last_name]}"
+  end
+
+  private
+
+  attr_reader :namely_profile
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ActiveRecord::Base
   end
 
   def namely_profiles
-    namely_connection.profiles
+    namely_connection.profiles.all.map { |profile| Profile.new(profile) }
   end
 
   def namely_fields

--- a/spec/models/net_suite/attribute_mapper_spec.rb
+++ b/spec/models/net_suite/attribute_mapper_spec.rb
@@ -30,7 +30,7 @@ describe NetSuite::AttributeMapper do
     end
 
     it "doesn't map empty values" do
-      delete_keys = [:email, :last_name]
+      delete_keys = ["email", "last_name"]
       profile_data = stubbed_profile_data
       delete_keys.each { |key| profile_data[key] = nil }
 
@@ -43,26 +43,26 @@ describe NetSuite::AttributeMapper do
     describe "value handling" do
       it "sets expected values in the profile for regular attributes" do
         attributes = {
-          email: "test@example.com",
-          first_name: "First",
-          home_phone: "919-555-1212",
-          last_name: "Last",
+          "email" => "test@example.com",
+          "first_name" => "First",
+          "home_phone" => "919-555-1212",
+          "last_name" => "Last",
         }
 
         profile_data = stubbed_profile_data.merge(attributes)
 
         export_attributes = export(profile_data)
 
-        expect(export_attributes["email"]).to eq(attributes[:email])
-        expect(export_attributes["firstName"]).to eq(attributes[:first_name])
-        expect(export_attributes["phone"]).to eq(attributes[:home_phone])
-        expect(export_attributes["lastName"]).to eq(attributes[:last_name])
+        expect(export_attributes["email"]).to eq(attributes["email"])
+        expect(export_attributes["firstName"]).to eq(attributes["first_name"])
+        expect(export_attributes["phone"]).to eq(attributes["home_phone"])
+        expect(export_attributes["lastName"]).to eq(attributes["last_name"])
       end
     end
 
     context "gender mapping" do
       it "maps 'Female to _female'" do
-        profile_data = stubbed_profile_data.merge(gender: "Female")
+        profile_data = stubbed_profile_data.merge("gender" => "Female")
 
         export_attributes = export(profile_data)
 
@@ -70,7 +70,7 @@ describe NetSuite::AttributeMapper do
       end
 
       it "maps 'Male to _male'" do
-        profile_data = stubbed_profile_data.merge(gender: "Male")
+        profile_data = stubbed_profile_data.merge("gender" => "Male")
 
         export_attributes = export(profile_data)
 
@@ -78,7 +78,7 @@ describe NetSuite::AttributeMapper do
       end
 
       it "maps nil to '_omitted'" do
-        profile_data = stubbed_profile_data.merge(gender: nil)
+        profile_data = stubbed_profile_data.merge("gender" => nil)
 
         export_attributes = export(profile_data)
 
@@ -86,7 +86,7 @@ describe NetSuite::AttributeMapper do
       end
 
       it "maps an empty string to '_omitted'" do
-        profile_data = stubbed_profile_data.merge(gender: "")
+        profile_data = stubbed_profile_data.merge("gender" => "")
 
         export_attributes = export(profile_data)
 
@@ -134,17 +134,17 @@ describe NetSuite::AttributeMapper do
 
   def stubbed_profile_data
     {
-      email: "test@example.com",
-      first_name: "First",
-      gender: "Female",
-      home_phone: "212-555-1212",
-      last_name: "Last"
+      "email" => "test@example.com",
+      "first_name" => "First",
+      "gender" => "Female",
+      "home_phone" => "212-555-1212",
+      "last_name" => "Last"
     }.merge(stubbed_job_title("Robot"))
   end
 
   def stubbed_job_title(title)
     {
-      job_title: {
+      "job_title" => {
         "id" => "1234",
         "title" => title
       }
@@ -152,6 +152,6 @@ describe NetSuite::AttributeMapper do
   end
 
   def stubbed_profile(data = stubbed_profile_data)
-    double(:profile, data)
+    Profile.new(data)
   end
 end

--- a/spec/models/net_suite/connection_spec.rb
+++ b/spec/models/net_suite/connection_spec.rb
@@ -104,8 +104,7 @@ describe NetSuite::Connection do
 
   describe "#sync" do
     it "exports to NetSuite" do
-      all_profiles = double(:all_profiles)
-      namely_profiles = double(:namely_profiles, all: all_profiles)
+      namely_profiles = double(:namely_profiles)
       client = stub_client(authorization: "x")
       connection = create(:net_suite_connection, authorization: "x")
       allow(connection.user).
@@ -125,7 +124,7 @@ describe NetSuite::Connection do
         to receive(:new).
         with(
           attribute_mapper: attribute_mapper,
-          namely_profiles: all_profiles,
+          namely_profiles: namely_profiles,
           net_suite: client
         ).
         and_return(export)

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe Profile do
+  describe "delegations" do
+    subject { Profile.new(stub_profile_data) }
+    it { should delegate_method(:[]).to(:namely_profile) }
+    it { should delegate_method(:update).to(:namely_profile) }
+  end
+
+  describe "#name" do
+    it "returns #first_name #last_name" do
+      profile_data = stub_profile_data.merge(
+        first_name: "First",
+        last_name: "Last"
+      )
+      profile = Profile.new(profile_data)
+
+      expect(profile.name).to eq("First Last")
+    end
+  end
+
+  def stub_profile_data
+    {
+      email: "test@example.com",
+      first_name: "First",
+      last_name: "Last",
+    }.merge(stub_job_title)
+  end
+
+  def stub_job_title(title = "Developer")
+    {
+      job_title: {
+        "id" => "1234",
+        "title" => title
+      }
+    }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -126,13 +126,18 @@ describe User do
 
   describe "#namely_profiles" do
     it "returns profiles from its Namely connection" do
-      profiles = double(:namely_profiles)
+      first_names = %w(Alice Bob)
+      profile_list = first_names.map { |name| stub_namely_profile(name) }
+
+      profiles = double(:namely_profiles, all: profile_list)
       stub_namely_connection profiles: profiles
       user = User.new
 
-      result = user.namely_profiles
+      profile_first_names = user.namely_profiles.map do |profile|
+        profile[:first_name]
+      end
 
-      expect(result).to eq(profiles)
+      expect(profile_first_names).to match_array(first_names)
     end
   end
 
@@ -146,6 +151,10 @@ describe User do
 
       expect(result).to eq(fields)
     end
+  end
+
+  def stub_namely_profile(first_name)
+    { first_name: first_name }
   end
 
   def stub_namely_connection(attributes)


### PR DESCRIPTION
* Profile will standardize some of how we work with Namely profiles that
  come through the Namely HRIS API
* Profile will handle #title and reach into the :job_title data
  structure to return the underlying title
* #name will return #first_name and #last_name concatenated
* Addresses a bug that manifested in SyncMailer where a name wasn't
  available in a sync result because the profile the result delegated
  the `#name` call to didn't understand `#name`, but as an OpenStruct,
  it returned nil
* For: https://trello.com/c/ANtvl85K/