### PR TITLE
Use different words for mapping/normalization

### DIFF
--- a/app/controllers/icims_candidate_retry_imports_controller.rb
+++ b/app/controllers/icims_candidate_retry_imports_controller.rb
@@ -19,7 +19,7 @@ class IcimsCandidateRetryImportsController < ApplicationController
   def namely_importer
     NamelyImporter.new(
       namely_connection: current_user.namely_connection,
-      attribute_mapper: Icims::AttributeMapper.new,
+      normalizer: Icims::Normalizer.new,
     )
   end
 

--- a/app/models/greenhouse/normalizer.rb
+++ b/app/models/greenhouse/normalizer.rb
@@ -1,5 +1,5 @@
 module Greenhouse
-  class AttributeMapper
+  class Normalizer
     # Initializes an attribute mapper using Namely Fields
     def initialize(namely_fields)
       @namely_fields = namely_fields

--- a/app/models/icims/connection.rb
+++ b/app/models/icims/connection.rb
@@ -30,7 +30,7 @@ module Icims
     end
 
     def required_namely_field
-      Icims::AttributeMapper.new.namely_identifier_field.to_s
+      Normalizer.new.namely_identifier_field.to_s
     end
 
     def set_api_key

--- a/app/models/icims/normalizer.rb
+++ b/app/models/icims/normalizer.rb
@@ -1,5 +1,5 @@
 module Icims
-  class AttributeMapper
+  class Normalizer
     def call(icims_candidate)
       {
         first_name: icims_candidate.firstname,

--- a/app/models/jobvite/connection.rb
+++ b/app/models/jobvite/connection.rb
@@ -1,10 +1,6 @@
 module Jobvite
   class Connection < ActiveRecord::Base
-    belongs_to(
-      :attribute_mapper,
-      dependent: :destroy,
-      class_name: "::AttributeMapper"
-    )
+    belongs_to :attribute_mapper, dependent: :destroy
     belongs_to :user
 
     validates :hired_workflow_state, presence: true
@@ -41,7 +37,7 @@ module Jobvite
     end
 
     def required_namely_field
-      jobvite_attribute_mapper.namely_identifier_field.to_s
+      normalizer.namely_identifier_field.to_s
     end
 
     def sync
@@ -61,15 +57,13 @@ module Jobvite
 
     def namely_importer
       NamelyImporter.new(
-        attribute_mapper: jobvite_attribute_mapper,
+        normalizer: normalizer,
         namely_connection: user.namely_connection,
       )
     end
 
-    def jobvite_attribute_mapper
-      Jobvite::AttributeMapper.new(
-        attribute_mapper: attribute_mapper
-      )
+    def normalizer
+      Normalizer.new(attribute_mapper: attribute_mapper)
     end
 
     class Result

--- a/app/models/jobvite/normalizer.rb
+++ b/app/models/jobvite/normalizer.rb
@@ -1,5 +1,5 @@
 module Jobvite
-  class AttributeMapper
+  class Normalizer
     def initialize(attribute_mapper:)
       @attribute_mapper = attribute_mapper
     end

--- a/app/models/namely_duplicate_filter.rb
+++ b/app/models/namely_duplicate_filter.rb
@@ -3,25 +3,25 @@ class NamelyDuplicateFilter
     new(options).filter(recent_hires)
   end
 
-  def initialize(attribute_mapper:, namely_connection:)
-    @attribute_mapper = attribute_mapper
+  def initialize(normalizer:, namely_connection:)
+    @normalizer = normalizer
     @namely_connection = namely_connection
   end
 
   def filter(unfiltered)
     unfiltered.reject do |row|
-      identifier = attribute_mapper.identifier(row)
+      identifier = normalizer.identifier(row)
       imported_identifiers.include?(identifier)
     end
   end
 
   private
 
-  attr_reader :attribute_mapper, :namely_connection
+  attr_reader :normalizer, :namely_connection
 
   def imported_identifiers
     @imported_identifiers ||= Set.new(profiles.map do |profile|
-      profile.send(attribute_mapper.namely_identifier_field)
+      profile.send(normalizer.namely_identifier_field)
     end)
   end
 

--- a/app/models/namely_importer.rb
+++ b/app/models/namely_importer.rb
@@ -7,29 +7,29 @@ class NamelyImporter
 
   def initialize(
     namely_connection:,
-    attribute_mapper:,
+    normalizer:,
     duplicate_filter: NamelyDuplicateFilter
   )
     @namely_connection = namely_connection
-    @attribute_mapper = attribute_mapper
+    @normalizer = normalizer
     @duplicate_filter = duplicate_filter
   end
 
   def import(recent_hires)
-    result = ImportResult.new(attribute_mapper)
+    result = ImportResult.new(normalizer)
     unique_recent_hires(recent_hires).inject(result) do |status, recent_hire|
-      status[recent_hire] = try_importing(attribute_mapper.call(recent_hire))
+      status[recent_hire] = try_importing(normalizer.call(recent_hire))
       status
     end
   end
 
   def single_import(candidate)
-    try_importing(attribute_mapper.call(candidate))
+    try_importing(normalizer.call(candidate))
   end
 
   private
 
-  attr_reader :namely_connection, :attribute_mapper, :duplicate_filter
+  attr_reader :namely_connection, :normalizer, :duplicate_filter
 
   def try_importing(attrs)
     if valid_attributes?(attrs)
@@ -55,7 +55,7 @@ class NamelyImporter
     duplicate_filter.filter(
       recent_hires,
       namely_connection: namely_connection,
-      attribute_mapper: attribute_mapper,
+      normalizer: normalizer,
     )
   end
 

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -1,12 +1,10 @@
 class NetSuite::Connection < ActiveRecord::Base
-  belongs_to :attribute_mapper,
-             dependent: :destroy,
-             class_name: "::AttributeMapper"
+  belongs_to :attribute_mapper, dependent: :destroy
   belongs_to :user
 
   validates :subsidiary_id, presence: true, allow_nil: true
 
-  delegate :export, to: :net_suite_attribute_mapper
+  delegate :export, to: :normalizer
 
   def integration_id
     :net_suite
@@ -56,7 +54,7 @@ class NetSuite::Connection < ActiveRecord::Base
 
   def sync
     NetSuite::Export.new(
-      attribute_mapper: net_suite_attribute_mapper,
+      normalizer: normalizer,
       namely_profiles: user.namely_profiles,
       net_suite: client
     ).perform
@@ -68,8 +66,8 @@ class NetSuite::Connection < ActiveRecord::Base
 
   private
 
-  def net_suite_attribute_mapper
-    @attribute_mapper ||= NetSuite::AttributeMapper.new(
+  def normalizer
+    @normalizer ||= NetSuite::Normalizer.new(
       attribute_mapper: attribute_mapper,
       configuration: self
     )

--- a/app/models/net_suite/export.rb
+++ b/app/models/net_suite/export.rb
@@ -1,7 +1,7 @@
 module NetSuite
   class Export
-    def initialize(attribute_mapper:, namely_profiles:, net_suite:)
-      @attribute_mapper = attribute_mapper
+    def initialize(normalizer:, namely_profiles:, net_suite:)
+      @normalizer = normalizer
       @namely_profiles = namely_profiles
       @net_suite = net_suite
     end
@@ -21,14 +21,14 @@ module NetSuite
     def export(profile)
       Employee.new(
         profile,
-        attribute_mapper: @attribute_mapper,
+        normalizer: @normalizer,
         net_suite: @net_suite
       ).export
     end
 
     class Employee
-      def initialize(profile, attribute_mapper:, net_suite:)
-        @attribute_mapper = attribute_mapper
+      def initialize(profile, normalizer:, net_suite:)
+        @normalizer = normalizer
         @profile = profile
         @net_suite = net_suite
       end
@@ -67,7 +67,7 @@ module NetSuite
       end
 
       def attributes
-        @attribute_mapper.export(@profile)
+        @normalizer.export(@profile)
       end
     end
 

--- a/app/models/net_suite/normalizer.rb
+++ b/app/models/net_suite/normalizer.rb
@@ -1,4 +1,4 @@
-class NetSuite::AttributeMapper
+class NetSuite::Normalizer
   GENDER_MAP = {
     "Male" => "_male",
     "Female" => "_female",

--- a/app/services/candidate_importer.rb
+++ b/app/services/candidate_importer.rb
@@ -31,7 +31,7 @@ class CandidateImporter
 
   def namely_importer
     NamelyImporter.new(
-      attribute_mapper: import_assistant.attribute_mapper,
+      normalizer: import_assistant.normalizer,
       namely_connection: user.namely_connection
     )
   end

--- a/app/services/greenhouse/candidate_import_assistant.rb
+++ b/app/services/greenhouse/candidate_import_assistant.rb
@@ -13,8 +13,8 @@ module Greenhouse
       @authentication_error = false
     end
 
-    def attribute_mapper
-      Greenhouse::AttributeMapper.new(
+    def normalizer
+      Normalizer.new(
         context.user.namely_fields.all
       )
     end

--- a/app/services/icims/candidate_import_assistant.rb
+++ b/app/services/icims/candidate_import_assistant.rb
@@ -10,8 +10,8 @@ module Icims
       @authentication_error = false
     end
 
-    def attribute_mapper
-      Icims::AttributeMapper.new
+    def normalizer
+      Normalizer.new
     end
 
     def candidate

--- a/spec/models/greenhouse/normalizer_spec.rb
+++ b/spec/models/greenhouse/normalizer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Greenhouse::AttributeMapper do
+describe Greenhouse::Normalizer do
   let(:namely_fields) do
     raw_objects = JSON.parse(
       File.read("spec/fixtures/api_responses/fields_with_greenhouse.json")

--- a/spec/models/icims/normalizer_spec.rb
+++ b/spec/models/icims/normalizer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Icims::AttributeMapper do
+describe Icims::Normalizer do
   describe "#call" do
     it "transforms a iCIMS candidate into a Hash appropriate for the Namely API" do
       mapper = described_class.new

--- a/spec/models/jobvite/normalizer_spec.rb
+++ b/spec/models/jobvite/normalizer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Jobvite::AttributeMapper do
+describe Jobvite::Normalizer do
   describe "#call" do
     it "provides the attribute mapper with a normalized profile hash" do
       attribute_mapper = stub_attribute_mapper

--- a/spec/models/namely_duplicate_filter_spec.rb
+++ b/spec/models/namely_duplicate_filter_spec.rb
@@ -13,16 +13,16 @@ describe NamelyDuplicateFilter do
         double("profile", external_service_id: "D4"),
       ])
       namely_connection = double("namely_connection", profiles: profiles)
-      attribute_mapper = double(
-        "attribute_mapper",
+      normalizer = double(
+        "normalizer",
         namely_identifier_field: :external_service_id,
       )
-      allow(attribute_mapper).to receive(:identifier) do |third_party_record|
+      allow(normalizer).to receive(:identifier) do |third_party_record|
         third_party_record.person_id
       end
       filter = described_class.new(
         namely_connection: namely_connection,
-        attribute_mapper: attribute_mapper,
+        normalizer: normalizer,
       )
 
       uniques = filter.filter(unfiltered)

--- a/spec/models/namely_importer_spec.rb
+++ b/spec/models/namely_importer_spec.rb
@@ -13,7 +13,7 @@ describe NamelyImporter do
       )
       recent_hires = [candidate]
       duplicate_filter = double("duplicate_filter", filter: recent_hires)
-      attribute_mapper = Proc.new do |original|
+      normalizer = Proc.new do |original|
         {
           first_name: original.name_the_first,
           last_name: original.name_the_last,
@@ -22,7 +22,7 @@ describe NamelyImporter do
       end
       importer = described_class.new(
         namely_connection: namely_connection,
-        attribute_mapper: attribute_mapper,
+        normalizer: normalizer,
         duplicate_filter: duplicate_filter,
       )
 
@@ -31,7 +31,7 @@ describe NamelyImporter do
       expect(duplicate_filter).to have_received(:filter).with(
         recent_hires_with_dupes,
         namely_connection: namely_connection,
-        attribute_mapper: attribute_mapper,
+        normalizer: normalizer,
       )
       expect(status).to be_an ImportResult
       expect(status[candidate]).to be_success
@@ -46,7 +46,7 @@ describe NamelyImporter do
       recent_hires = [candidate]
       importer = described_class.new(
         namely_connection: namely_connection,
-        attribute_mapper: -> (original) { original },
+        normalizer: -> (original) { original },
         duplicate_filter: duplicate_filter,
       )
 
@@ -67,7 +67,7 @@ describe NamelyImporter do
         name_the_last: "Murphy",
         email: "crash.override@example.com",
       )
-      attribute_mapper = Proc.new do |original|
+      normalizer = Proc.new do |original|
         {
           first_name: original.name_the_first,
           last_name: original.name_the_last,
@@ -76,7 +76,7 @@ describe NamelyImporter do
       end
       importer = described_class.new(
         namely_connection: namely_connection,
-        attribute_mapper: attribute_mapper,
+        normalizer: normalizer,
       )
 
       status = importer.single_import(candidate)

--- a/spec/models/net_suite/connection_spec.rb
+++ b/spec/models/net_suite/connection_spec.rb
@@ -112,18 +112,18 @@ describe NetSuite::Connection do
         and_return(namely_profiles)
       results = double(:results)
       export = double(NetSuite::Export, perform: results)
-      attribute_mapper = double("attribute_mapper")
-      allow(NetSuite::AttributeMapper).
+      normalizer = double("normalizer")
+      allow(NetSuite::Normalizer).
         to receive(:new).
         with(
           attribute_mapper: connection.attribute_mapper,
           configuration: connection
         ).
-        and_return(attribute_mapper)
+        and_return(normalizer)
       allow(NetSuite::Export).
         to receive(:new).
         with(
-          attribute_mapper: attribute_mapper,
+          normalizer: normalizer,
           namely_profiles: namely_profiles,
           net_suite: client
         ).
@@ -138,7 +138,7 @@ describe NetSuite::Connection do
   describe "#export" do
     it do
       should delegate_method(:export).
-        to(:net_suite_attribute_mapper).
+        to(:normalizer).
         as(:export)
     end
   end

--- a/spec/models/net_suite/export_spec.rb
+++ b/spec/models/net_suite/export_spec.rb
@@ -25,10 +25,10 @@ describe NetSuite::Export do
 
         net_suite = stub_net_suite(success: true, internalId: "1234")
         mapped_attributes = double("mapped_attributes")
-        attribute_mapper = stub_attribute_mapper(to: mapped_attributes)
+        normalizer = stub_normalizer(to: mapped_attributes)
 
         results = perform_export(
-          attribute_mapper: attribute_mapper,
+          normalizer: normalizer,
           net_suite: net_suite,
           profiles: profiles
         )
@@ -50,14 +50,14 @@ describe NetSuite::Export do
       it "returns a result with updated profiles" do
         profile = stub_profile({}, netsuite_id: "1234")
         mapped_attributes = double("mapped_attributes")
-        attribute_mapper = stub_attribute_mapper(
+        normalizer = stub_normalizer(
           from: profile,
           to: mapped_attributes
         )
         net_suite = stub_net_suite(success: true)
 
         results = perform_export(
-          attribute_mapper: attribute_mapper,
+          normalizer: normalizer,
           net_suite: net_suite,
           profiles: [profile]
         )
@@ -126,9 +126,9 @@ describe NetSuite::Export do
     end
   end
 
-  def stub_attribute_mapper(from: anything, to: double("attributes"))
-    double("attribute_mapper").tap do |attribute_mapper|
-      allow(attribute_mapper).
+  def stub_normalizer(from: anything, to: double("attributes"))
+    double("normalizer").tap do |normalizer|
+      allow(normalizer).
         to receive(:export).
         with(from).
         at_least(1).
@@ -137,12 +137,12 @@ describe NetSuite::Export do
   end
 
   def perform_export(
-    attribute_mapper: stub_attribute_mapper,
+    normalizer: stub_normalizer,
     net_suite:,
     profiles:
   )
     NetSuite::Export.new(
-      attribute_mapper: attribute_mapper,
+      normalizer: normalizer,
       net_suite: net_suite,
       namely_profiles: profiles
     ).perform

--- a/spec/models/net_suite/normalizer_spec.rb
+++ b/spec/models/net_suite/normalizer_spec.rb
@@ -1,23 +1,23 @@
 require "rails_helper"
 
-describe NetSuite::AttributeMapper do
+describe NetSuite::Normalizer do
   let(:configuration) { double("configuration", subsidiary_id: "123") }
-  let(:netsuite_attribute_mapper) do
-    NetSuite::AttributeMapper.new(
+  let(:normalizer) do
+    NetSuite::Normalizer.new(
       attribute_mapper: create(:net_suite_connection).attribute_mapper,
       configuration: configuration
     )
   end
 
   describe "delegation" do
-    subject { netsuite_attribute_mapper }
+    subject { normalizer }
     it { should delegate_method(:field_mappings).to(:attribute_mapper) }
     it { should delegate_method(:mapping_direction).to(:attribute_mapper) }
   end
 
   describe "#export" do
     it "returns a converted data structure based on field mappings" do
-      field_mappings = netsuite_attribute_mapper.field_mappings
+      field_mappings = normalizer.field_mappings
       export_profile_keys = field_mappings.map(&:integration_field_name)
 
       export_attributes = export
@@ -127,7 +127,7 @@ describe NetSuite::AttributeMapper do
   end
 
   def export(profile_data = stubbed_profile_data)
-    netsuite_attribute_mapper.export(stubbed_profile(profile_data))
+    normalizer.export(stubbed_profile(profile_data))
   end
 
   def stubbed_profile_data

--- a/spec/services/greenhouse/candidate_import_assistant_spec.rb
+++ b/spec/services/greenhouse/candidate_import_assistant_spec.rb
@@ -27,16 +27,16 @@ describe Greenhouse::CandidateImportAssistant do
     end
   end
 
-  describe "#attribute_mapper" do
-    it "returns an attribute mapper object" do
+  describe "#normalizer" do
+    it "returns a normalizer object" do
       context = candidate_importer_double
       import_assistant = Greenhouse::CandidateImportAssistant.new(
         assistant_arguments: { signature: "foo" },
         context: context
       )
 
-      expect(import_assistant.attribute_mapper).to be_instance_of(
-        Greenhouse::AttributeMapper
+      expect(import_assistant.normalizer).to be_instance_of(
+        Greenhouse::Normalizer
       )
     end
   end

--- a/spec/services/icims/candidate_import_assistant_spec.rb
+++ b/spec/services/icims/candidate_import_assistant_spec.rb
@@ -13,13 +13,13 @@ describe Icims::CandidateImportAssistant do
     end
   end
 
-  describe "#attribute_mapper" do
-    it "returns an attribute mapper object" do
+  describe "#normalizer" do
+    it "returns a normalizer object" do
       context = candidate_importer_double
       import_assistant = Icims::CandidateImportAssistant.new(context: context)
 
-      expect(import_assistant.attribute_mapper).to be_instance_of(
-        Icims::AttributeMapper
+      expect(import_assistant.normalizer).to be_instance_of(
+        Icims::Normalizer
       )
     end
   end


### PR DESCRIPTION
It's confusing to name both the high-level mapper model and the
integration-specific normalization strategies "attribute mappers."

This commit switches to consistently calling the attribute mapper model
"attribute mapper," and calling the strategies "normalizer."