### PR TITLE
Contact NetSuite, get a list of employees, determine profile fields

### DIFF
--- a/app/models/net_suite/client.rb
+++ b/app/models/net_suite/client.rb
@@ -1,5 +1,10 @@
 module NetSuite
   class Client
+    REQUEST_BASE = "/hubs/erp"
+    EMPLOYEE_REQUEST = REQUEST_BASE + "/employees"
+    SUBSIDIARY_REQUEST = REQUEST_BASE + "/lookups/subsidiary"
+    INSTANCES = "/instances"
+
     delegate :get_json, to: :request
     delegate :submit_json, to: :request
 
@@ -35,7 +40,7 @@ module NetSuite
     def create_instance(params)
       submit_json(
         :post,
-        "/instances",
+        INSTANCES,
         "configuration" => {
           "user.username" => params[:email],
           "user.password" => params[:password],
@@ -53,7 +58,7 @@ module NetSuite
     def create_employee(params)
       submit_json(
         :post,
-        "/hubs/erp/employees",
+        EMPLOYEE_REQUEST,
         params
       )
     end
@@ -61,13 +66,19 @@ module NetSuite
     def update_employee(id, params)
       submit_json(
         :patch,
-        "/hubs/erp/employees/#{id}",
+        "#{EMPLOYEE_REQUEST}/#{id}",
         params
       )
     end
 
     def subsidiaries
-      get_json("/hubs/erp/lookups/subsidiary")
+      get_json(SUBSIDIARY_REQUEST)
+    end
+
+    def profile_fields
+      @profile_fields ||= NetSuite::EmployeeFieldsLoader.new(
+        request: request
+      ).load_profile_fields
     end
 
     def request

--- a/app/models/net_suite/employee_field.rb
+++ b/app/models/net_suite/employee_field.rb
@@ -1,0 +1,18 @@
+module NetSuite
+  class EmployeeField
+    attr_reader :name, :value
+
+    def initialize(name:, value:)
+      @name = name
+      @value = value
+    end
+
+    def label
+      name.titleize
+    end
+
+    def type
+      TypeForField.for_field(name: name, value: value)
+    end
+  end
+end

--- a/app/models/net_suite/employee_fields_loader.rb
+++ b/app/models/net_suite/employee_fields_loader.rb
@@ -1,0 +1,27 @@
+module NetSuite
+  class EmployeeFieldsLoader
+    EMPLOYEE_LIMIT = 5
+
+    def initialize(request:)
+      @request = request
+    end
+
+    def load_profile_fields
+      employees = request.get_json(
+        "#{NetSuite::Client::EMPLOYEE_REQUEST}?pageSize=#{EMPLOYEE_LIMIT}"
+      )
+
+      convert_employee_data_to_profile_fields(employees.first)
+    end
+
+    def convert_employee_data_to_profile_fields(employee)
+      employee.map do |name, value|
+        NetSuite::EmployeeField.new(name: name, value: value)
+      end
+    end
+
+    private
+
+    attr_reader :request
+  end
+end

--- a/app/models/type_for_field.rb
+++ b/app/models/type_for_field.rb
@@ -1,0 +1,49 @@
+class TypeForField
+  def self.for_field(name:, value:)
+    new(name: name, value: value).determine_type
+  end
+
+  def initialize(name:, value:)
+    @name = name
+    @value = value
+  end
+
+  def determine_type
+    case
+    when boolean?; "boolean"
+    when date?; "date"
+    when email?; "email"
+    when fixnum?; "fixnum"
+    when object?; "object"
+    when text?; "text"
+    end
+  end
+
+  private
+
+  def boolean?
+    value.class == TrueClass || value.class == FalseClass
+  end
+
+  def date?
+    value.class == Fixnum && name.match(/Date/)
+  end
+
+  def email?
+    value.class == String && name.match(/email/)
+  end
+
+  def fixnum?
+    value.class == Fixnum && !name.match(/Date/)
+  end
+
+  def object?
+    value.class == Hash
+  end
+
+  def text?
+    value.class == String
+  end
+
+  attr_reader :name, :value
+end

--- a/spec/models/net_suite/client_spec.rb
+++ b/spec/models/net_suite/client_spec.rb
@@ -262,17 +262,41 @@ describe NetSuite::Client do
         ).
         to_return(status: 200, body: subsidiaries.to_json)
 
-      client = NetSuite::Client.new(
-        user: build_stubbed(:user),
-        user_secret: "user-secret",
-        organization_secret: "org-secret",
-        element_secret: "element-secret"
-      )
-
       result = client.subsidiaries
 
       expect(result).to be_success
       expect(result.to_a).to eq(subsidiaries)
     end
+  end
+
+  describe "#profile_fields" do
+    it "gets a currest list of NetSuite employee profile fields" do
+      fields = [
+        double(:employee_field),
+        double(:employee_field)
+      ]
+
+      fields_loader = instance_spy(
+        NetSuite::EmployeeFieldsLoader,
+        load_profile_fields: fields
+      )
+
+      netsuite_client = client
+
+      allow(NetSuite::EmployeeFieldsLoader).to receive(:new).
+        with(request: netsuite_client.request).
+        and_return(fields_loader)
+
+      expect(netsuite_client.profile_fields).to match_array(fields)
+    end
+  end
+
+  def client
+    NetSuite::Client.new(
+      user: build_stubbed(:user),
+      user_secret: "user-secret",
+      organization_secret: "org-secret",
+      element_secret: "element-secret"
+    )
   end
 end

--- a/spec/models/net_suite/employee_field_spec.rb
+++ b/spec/models/net_suite/employee_field_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe NetSuite::EmployeeField do
+  describe "#label" do
+    it "provides a valid label for camelCase" do
+      employee_field = described_class.new(name: "homePhone", value: "foo")
+
+      expect(employee_field.label).to eq("Home Phone")
+    end
+
+    it "provides a valid label for doubleCamelCase" do
+      employee_field = described_class.new(
+        name: "globalSubscriptionStatus",
+        value: {}
+      )
+
+      expect(employee_field.label).to eq("Global Subscription Status")
+    end
+
+    it "provides a valid label for single words" do
+      employee_field = described_class.new(name: "phone", value: "Foo")
+
+      expect(employee_field.label).to eq("Phone")
+    end
+  end
+
+  describe "#type" do
+    it "provides a type" do
+      employee_field = described_class.new(
+        name: "email",
+        value: "test@example.com"
+      )
+
+      expect(employee_field.type).to eq("email")
+    end
+  end
+end

--- a/spec/models/net_suite/employee_fields_loader_spec.rb
+++ b/spec/models/net_suite/employee_fields_loader_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+
+describe NetSuite::EmployeeFieldsLoader do
+  describe "#retrieve_fields" do
+    it "gets a currest list of NetSuite employee profile fields" do
+      stubbed_employee_data = stub_employee_data(
+        expenseLimit: 100,
+        firstName: "Ralph",
+        hireDate: Time.now.to_i,
+        isSalesRep: false,
+        lastName: "Bot",
+        officePhone: "212-555-1212",
+        subsidiary: {}
+      )
+
+      stub_request(
+        :get,
+        "https://api.cloud-elements.com/elements/api-v2" \
+        "/hubs/erp/employees?pageSize=5"
+      ).with(
+        headers: {
+          "Authorization" => "User user-secret, " \
+          "Organization org-secret, " \
+          "Element element-secret",
+          "Content-Type" => "application/json"
+        }
+      ).to_return(
+        body: stubbed_employee_data.to_json,
+        status: 200
+      )
+
+      request = NetSuite::Client.new(
+        element_secret: "element-secret",
+        organization_secret: "org-secret",
+        user: create(:user),
+        user_secret: "user-secret",
+      ).request
+
+      loader = described_class.new(request: request)
+      fields = loader.load_profile_fields
+      labels = fields.map(&:label)
+      types = fields.map(&:type)
+
+      expected_labels = [
+        "Expense Limit",
+        "First Name",
+        "Hire Date",
+        "Is Sales Rep",
+        "Last Name",
+        "Office Phone",
+        "Subsidiary"
+      ]
+
+      expected_labels.each do |expected_label|
+        expect(labels).to include(expected_label)
+      end
+
+      %w(boolean date fixnum object text).each do |type|
+        expect(types).to include(type)
+      end
+    end
+  end
+
+  def stub_employee_data(options = {})
+    [
+      {
+        expenseLimit: 0,
+        firstName: "First",
+        hireDate: Time.now.to_i,
+        isSalesRep: false,
+        lastName: "Last",
+        officePhone: "919-555-0000",
+        subsidiary: {}
+      }.merge(options).deep_stringify_keys
+    ]
+  end
+end

--- a/spec/models/type_for_field_spec.rb
+++ b/spec/models/type_for_field_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe TypeForField do
+  describe ".for_field" do
+    it "reports 'boolean' for field that came in with boolean values" do
+      fields = [
+        described_class.for_field(name: "foo", value: false),
+        described_class.for_field(name: "foo", value: true)
+      ]
+
+      expect(fields).to match_array(["boolean", "boolean"])
+    end
+
+    it "reports 'date' for fixnums on date fields" do
+      field = described_class.for_field(
+        name: "hireDate",
+        value: 1234567890
+      )
+
+      expect(field).to eq("date")
+      expect(field).not_to eq("fixnum")
+    end
+
+    it "reports 'email' for strings with an appropriate field name" do
+      field = described_class.for_field(
+        name: "email",
+        value: "test@example.com"
+      )
+
+      expect(field).to eq("email")
+    end
+
+    it "reports 'fixnum' for fixnums" do
+      field = described_class.for_field(name: "foo", value: 1234)
+
+      expect(field).to eq("fixnum")
+      expect(field).not_to eq("date")
+    end
+
+    it "reports 'object' for hashes" do
+      field = described_class.for_field(name: "bar", value: {})
+
+      expect(field).to eq("object")
+    end
+
+    it "reports 'text' for strings" do
+      field = described_class.for_field(name: "foo", value: "Bar")
+
+      expect(field).to eq("text")
+    end
+  end
+end


### PR DESCRIPTION
* NetSuite, through Cloud Elements, doesn't have a way to directly list
  what fields are available on profiles
* We want to get a full list of available fields for each integration
* Introduces NetSuite::EmployeeField
* Created fro NetSuite::Client#profile_fields
* We aren't storing the information, but making it available when field
  mappings between Namely and NetSuite are edited
* This does not yet handle custom fields, since those are going to be
  more complex
* Since we don't want to count on Employee ids within NetSuite, we
  request 5 employees, since that's the smallest window allowed for
  getting a list of employees
* Matches, where it can, the types of fields that we support in Namely
  for mapping
  * date
  * text
  * email
* Also identifies other types that we don't yet handle in Namely for
  mapping
  * boolean
  * fixnum
  * object
* The names for the non-supported field types may change
* NetSuite::Client#profile_fields just hands back a list of
  NetSuite::EmployeeField objects and presumes supported type filtering
  is handled downstream
* For: https://trello.com/c/mThbJz4M/