### PR TITLE
Introduce installations

### DIFF
--- a/app/controllers/syncs_controller.rb
+++ b/app/controllers/syncs_controller.rb
@@ -1,6 +1,8 @@
 class SyncsController < IntegrationController
   def create
-    Delayed::Job.enqueue SyncJob.new(integration_id, current_user.id)
+    Delayed::Job.enqueue(
+      SyncJob.new(integration_id, current_user.installation_id)
+    )
     connection
   end
 end

--- a/app/models/attribute_mapper.rb
+++ b/app/models/attribute_mapper.rb
@@ -10,14 +10,9 @@ class AttributeMapper < ActiveRecord::Base
   )
   # Unsupported: address checkboxes file image salary
 
-  belongs_to :user
   has_many :field_mappings, dependent: :destroy
 
-  validates :user, presence: true
-  validates :user_id, presence: true
-
   accepts_nested_attributes_for :field_mappings
-
 
   def build_field_mappings(default_field_mapping)
     default_field_mapping.each_pair do |namely_field, integration_field|
@@ -44,13 +39,5 @@ class AttributeMapper < ActiveRecord::Base
         accumulator.merge!(field_mapping.namely_field_name.to_sym => value)
       end
     end
-  end
-
-  def namely_fields
-    user.
-      namely_fields.
-      all.
-      select { |field| SUPPORTED_TYPES.include?(field.type) }.
-      map { |field| [field.label, field.name] }
   end
 end

--- a/app/models/attribute_mapper_factory.rb
+++ b/app/models/attribute_mapper_factory.rb
@@ -11,7 +11,7 @@ class AttributeMapperFactory
   private
 
   def assign_attribute_mapper(defaults)
-    AttributeMapper.create!(user: @connection.user).tap do |attribute_mapper|
+    AttributeMapper.create!.tap do |attribute_mapper|
       @connection.update!(attribute_mapper: attribute_mapper)
       defaults.each do |integration_field_name, namely_field_name|
         attribute_mapper.field_mappings.create!(

--- a/app/models/authentication_notifier.rb
+++ b/app/models/authentication_notifier.rb
@@ -1,7 +1,7 @@
 class AuthenticationNotifier
-  def initialize(integration_id:, user:)
+  def initialize(integration_id:, installation:)
     @integration_id = integration_id
-    @user = user
+    @installation = installation
   end
 
   def integration_name
@@ -16,7 +16,7 @@ class AuthenticationNotifier
   private
 
   def deliver_unauthorized_notification(exception)
-    user.send_connection_notification(
+    installation.send_connection_notification(
       integration_id: integration_id,
       message: exception.message
     )
@@ -25,9 +25,9 @@ class AuthenticationNotifier
   def log_unauthorized_exception(exception)
     Rails.logger.error(
       "#{exception.class} error #{exception.message} for " \
-      "user_id: #{user.id} with #{integration_name}"
+      "installation_id: #{installation.id} with #{integration_name}"
     )
   end
 
-  attr_reader :integration_id, :user
+  attr_reader :integration_id, :installation
 end

--- a/app/models/bulk_sync.rb
+++ b/app/models/bulk_sync.rb
@@ -1,12 +1,12 @@
 class BulkSync
-  def initialize(integration_id:, users:)
+  def initialize(integration_id:, installations:)
     @integration_id = integration_id
-    @users = users
+    @installations = installations
   end
 
   def sync
-    @users.ready_to_sync_with(@integration_id).each do |user|
-      Delayed::Job.enqueue SyncJob.new(@integration_id, user.id)
+    @installations.ready_to_sync_with(@integration_id).each do |installations|
+      Delayed::Job.enqueue SyncJob.new(@integration_id, installations.id)
     end
   end
 end

--- a/app/models/greenhouse/connection.rb
+++ b/app/models/greenhouse/connection.rb
@@ -1,7 +1,6 @@
 module Greenhouse
   class Connection < ActiveRecord::Base
-    belongs_to :user
-    validates :user_id, presence: true
+    belongs_to :installation
     validates :secret_key, uniqueness: true
     before_create :set_secret_key
 

--- a/app/models/icims/authorized_request.rb
+++ b/app/models/icims/authorized_request.rb
@@ -1,7 +1,7 @@
 module Icims
   class AuthorizedRequest < SimpleDelegator
     HMAC_SHA256_HEADER = "x-icims-v1-hmac-sha256"
-    delegate :user, to: :connection
+    delegate :installation, to: :connection
 
     def initialize(connection:, request:)
       super(request)
@@ -68,7 +68,7 @@ module Icims
       r.execute
     rescue RestClient::Unauthorized => exception
       unauthorized_exception = Unauthorized.new(exception.message)
-      user.send_connection_notification(
+      installation.send_connection_notification(
         integration_id: "icims",
         message: unauthorized_exception.message
       )

--- a/app/models/icims/connection.rb
+++ b/app/models/icims/connection.rb
@@ -1,7 +1,6 @@
 module Icims
   class Connection < ActiveRecord::Base
-    belongs_to :user
-    validates :user_id, presence: true
+    belongs_to :installation
     validates :api_key, uniqueness: true
     before_create :set_api_key
 

--- a/app/models/importer.rb
+++ b/app/models/importer.rb
@@ -1,12 +1,12 @@
 class Importer
   def initialize(
-    user:,
     client:,
     connection:,
-    namely_importer:
+    namely_importer:,
+    namely_connection:
   )
 
-    @user = user
+    @namely_connection = namely_connection
     @client = client
     @connection = connection
     @namely_importer = namely_importer
@@ -22,8 +22,7 @@ class Importer
 
   private
 
-  attr_reader :connection, :client, :namely_importer, :user
-  delegate :namely_connection, to: :user
+  attr_reader :connection, :client, :namely_connection, :namely_importer
 
   def import_recent_hires
     namely_importer.import(recent_hires)

--- a/app/models/installation.rb
+++ b/app/models/installation.rb
@@ -1,0 +1,67 @@
+class Installation < ActiveRecord::Base
+  has_many :users, dependent: :destroy
+  has_one(
+    :greenhouse_connection,
+    class_name: "Greenhouse::Connection",
+    dependent: :destroy
+  )
+  has_one(
+    :icims_connection,
+    class_name: "Icims::Connection",
+    dependent: :destroy
+  )
+  has_one(
+    :jobvite_connection,
+    class_name: "Jobvite::Connection",
+    dependent: :destroy
+  )
+  has_one(
+    :net_suite_connection,
+    class_name: "NetSuite::Connection",
+    dependent: :destroy
+  )
+
+  validates :subdomain, presence: true, uniqueness: true
+
+  def self.ready_to_sync_with(integration)
+    association = "#{integration}_connection"
+    joins(association.to_sym).
+      where(association.pluralize => { found_namely_field: true })
+  end
+
+  def jobvite_connection
+    super || Jobvite::Connection.create!(installation: self)
+  end
+
+  def icims_connection
+    super || Icims::Connection.create!(installation: self)
+  end
+
+  def greenhouse_connection
+    super || Greenhouse::Connection.create!(installation: self)
+  end
+
+  def net_suite_connection
+    super || NetSuite::Connection.create!(installation: self)
+  end
+
+  def send_connection_notification(*arguments)
+    users.each do |user|
+      user.send_connection_notification(*arguments)
+    end
+  end
+
+  def namely_connection
+    owner.namely_connection
+  end
+
+  def namely_profiles
+    owner.namely_profiles
+  end
+
+  private
+
+  def owner
+    users.first
+  end
+end

--- a/app/models/jobvite/client.rb
+++ b/app/models/jobvite/client.rb
@@ -19,7 +19,7 @@ module Jobvite
     attr_reader :connection
 
     class CandidatePage
-      delegate :user, to: :connection
+      delegate :installation, to: :connection
 
       attr_reader :response_code
 
@@ -80,7 +80,7 @@ module Jobvite
       def raise_on_authenticaton_error
         if invalid_secret_key.present?
           exception = Unauthorized.new(json_response["responseMessage"])
-          user.send_connection_notification(
+          installation.send_connection_notification(
             integration_id: "jobvite",
             message: exception.message
           )

--- a/app/models/jobvite/connection.rb
+++ b/app/models/jobvite/connection.rb
@@ -1,7 +1,7 @@
 module Jobvite
   class Connection < ActiveRecord::Base
     belongs_to :attribute_mapper, dependent: :destroy
-    belongs_to :user
+    belongs_to :installation
 
     validates :hired_workflow_state, presence: true
 
@@ -50,16 +50,20 @@ module Jobvite
       Importer.new(
         client: Jobvite::Client.new(self),
         connection: self,
+        namely_connection: namely_connection,
         namely_importer: namely_importer,
-        user: user,
       ).import
     end
 
     def namely_importer
       NamelyImporter.new(
         normalizer: normalizer,
-        namely_connection: user.namely_connection,
+        namely_connection: namely_connection,
       )
+    end
+
+    def namely_connection
+      installation.namely_connection
     end
 
     def normalizer

--- a/app/models/net_suite/client.rb
+++ b/app/models/net_suite/client.rb
@@ -8,21 +8,18 @@ module NetSuite
     delegate :get_json, to: :request
     delegate :submit_json, to: :request
 
-    def self.from_env(user)
+    def self.from_env
       new(
-        user: user,
         user_secret: ENV["CLOUD_ELEMENTS_USER_SECRET"],
         organization_secret: ENV["CLOUD_ELEMENTS_ORGANIZATION_SECRET"]
       )
     end
 
     def initialize(
-      user:,
       user_secret:,
       organization_secret:,
       element_secret: nil
     )
-      @user = user
       @user_secret = user_secret
       @organization_secret = organization_secret
       @element_secret = element_secret
@@ -30,7 +27,6 @@ module NetSuite
 
     def authorize(element_secret)
       self.class.new(
-        user: @user,
         user_secret: @user_secret,
         organization_secret: @organization_secret,
         element_secret: element_secret

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -1,6 +1,6 @@
 class NetSuite::Connection < ActiveRecord::Base
   belongs_to :attribute_mapper, dependent: :destroy
-  belongs_to :user
+  belongs_to :installation
 
   validates :subsidiary_id, presence: true, allow_nil: true
 
@@ -55,13 +55,13 @@ class NetSuite::Connection < ActiveRecord::Base
   def sync
     NetSuite::Export.new(
       normalizer: normalizer,
-      namely_profiles: user.namely_profiles,
+      namely_profiles: installation.namely_profiles,
       net_suite: client
     ).perform
   end
 
   def client
-    NetSuite::Client.from_env(user).authorize(authorization)
+    NetSuite::Client.from_env.authorize(authorization)
   end
 
   private

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -10,6 +10,7 @@ class Session
 
   def user
     @user ||= user_model.find_or_initialize_by(
+      installation: installation,
       namely_user_id: namely_user.id,
       subdomain: subdomain,
     ).tap do |user|
@@ -46,6 +47,12 @@ class Session
 
   def refresh_token
     tokens.fetch("refresh_token")
+  end
+
+  def installation
+    @installation ||= Installation.find_or_initialize_by(
+      subdomain: subdomain
+    )
   end
 
   def tokens

--- a/app/services/candidate_importer.rb
+++ b/app/services/candidate_importer.rb
@@ -32,38 +32,42 @@ class CandidateImporter
   def namely_importer
     NamelyImporter.new(
       normalizer: import_assistant.normalizer,
-      namely_connection: user.namely_connection
+      namely_connection: installation.namely_connection
     )
   end
 
   def notifier
     AuthenticationNotifier.new(
       integration_id: assistant_class::INTEGRATION_ID,
-      user: user
+      installation: installation
     )
   end
 
-  def user
-    connection.user
+  def installation
+    connection.installation
   end
 
   private
 
   def notify_of_successful_import
-    mailer.delay.successful_import(
-      candidate: import_assistant.candidate,
-      email: user.email,
-      integration_id: assistant_class::INTEGRATION_ID
-    )
+    installation.users.each do |user|
+      mailer.delay.successful_import(
+        candidate: import_assistant.candidate,
+        email: user.email,
+        integration_id: assistant_class::INTEGRATION_ID
+      )
+    end
   end
 
   def notify_of_unsuccessful_import
-    mailer.delay.unsuccessful_import(
-      candidate: import_assistant.candidate,
-      email: user.email,
-      integration_id: assistant_class::INTEGRATION_ID,
-      status: import_assistant.import_candidate
-    )
+    installation.users.each do |user|
+      mailer.delay.unsuccessful_import(
+        candidate: import_assistant.candidate,
+        email: user.email,
+        integration_id: assistant_class::INTEGRATION_ID,
+        status: import_assistant.import_candidate
+      )
+    end
   end
 
   def report_import_results

--- a/app/services/greenhouse/candidate_import_assistant.rb
+++ b/app/services/greenhouse/candidate_import_assistant.rb
@@ -15,7 +15,7 @@ module Greenhouse
 
     def normalizer
       Normalizer.new(
-        context.user.namely_fields.all
+        context.installation.namely_connection.fields.all
       )
     end
 

--- a/app/services/user_check_namely_field.rb
+++ b/app/services/user_check_namely_field.rb
@@ -33,6 +33,6 @@ class UserCheckNamelyField < SimpleDelegator
   end
 
   def namely_connection
-    user.namely_connection
+    installation.namely_connection
   end
 end

--- a/app/views/mappings/edit.html.erb
+++ b/app/views/mappings/edit.html.erb
@@ -14,7 +14,7 @@
           "field_mapping",
           field_mapping: fields.object,
           fields: fields,
-          namely_fields: @attribute_mapper.namely_fields
+          namely_fields: current_user.namely_fields_by_label
         ) %>
       <% end %>
     </tbody>

--- a/db/migrate/20150806192706_create_installations.rb
+++ b/db/migrate/20150806192706_create_installations.rb
@@ -1,0 +1,29 @@
+class CreateInstallations < ActiveRecord::Migration
+  def up
+    create_table :installations do |t|
+      t.string :subdomain, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :installations, :subdomain, unique: true
+
+    insert(<<-SQL)
+      INSERT INTO installations
+        (subdomain, created_at, updated_at)
+      SELECT DISTINCT
+        subdomain, #{now}, #{now}
+      FROM users
+    SQL
+  end
+
+  def down
+    drop_table :installations
+  end
+
+  private
+
+  def now
+    "'#{Time.now.to_s(:db)}' :: timestamp"
+  end
+end

--- a/db/migrate/20150807150624_adjust_user_add_reference_to_installation.rb
+++ b/db/migrate/20150807150624_adjust_user_add_reference_to_installation.rb
@@ -1,0 +1,19 @@
+class AdjustUserAddReferenceToInstallation < ActiveRecord::Migration
+  def up
+    add_reference :users, :installation, index: true, foreign_key: true
+
+    update(<<-SQL)
+      UPDATE users SET installation_id = (
+        SELECT installations.id
+        FROM installations
+        WHERE installations.subdomain = users.subdomain
+      )
+    SQL
+
+    change_column_null :users, :installation_id, false
+  end
+
+  def down
+    remove_reference :users, :installation
+  end
+end

--- a/db/migrate/20150810170254_add_installation_id_to_connections.rb
+++ b/db/migrate/20150810170254_add_installation_id_to_connections.rb
@@ -1,0 +1,44 @@
+class AddInstallationIdToConnections < ActiveRecord::Migration
+  def up
+    add_installation_id_to :greenhouse_connections
+    add_installation_id_to :icims_connections
+    add_installation_id_to :jobvite_connections
+    add_installation_id_to :net_suite_connections
+  end
+
+  def down
+    remove_installation_id_from :net_suite_connections
+    remove_installation_id_from :jobvite_connections
+    remove_installation_id_from :icims_connections
+    remove_installation_id_from :greenhouse_connections
+  end
+
+  private
+
+  def add_installation_id_to(table_name)
+    add_reference(
+      table_name,
+      :installation,
+      foreign_key: true,
+      index: true,
+      unique: true
+    )
+
+    update(<<-SQL)
+      UPDATE #{table_name}
+      SET installation_id = (
+        SELECT users.installation_id
+        FROM users
+        WHERE #{table_name}.user_id = users.id
+        ORDER BY updated_at DESC
+        LIMIT 1
+      )
+    SQL
+
+    change_column_null table_name, :installation_id, false
+  end
+
+  def remove_installation_id_from(table_name)
+    remove_reference table_name, :installation
+  end
+end

--- a/db/migrate/20150810174108_remove_users_from_connections.rb
+++ b/db/migrate/20150810174108_remove_users_from_connections.rb
@@ -1,0 +1,33 @@
+class RemoveUsersFromConnections < ActiveRecord::Migration
+  def up
+    remove_column :greenhouse_connections, :user_id
+    remove_column :icims_connections, :user_id
+    remove_column :jobvite_connections, :user_id
+    remove_column :net_suite_connections, :user_id
+  end
+
+  def down
+    add_user_id_to :greenhouse_connections
+    add_user_id_to :icims_connections
+    add_user_id_to :jobvite_connections
+    add_user_id_to :net_suite_connections
+  end
+
+  private
+
+  def add_user_id_to(table_name)
+    add_column table_name, :user_id, :integer
+
+    update(<<-SQL)
+      UPDATE #{table_name}
+      SET user_id = (
+        SELECT users.id
+        FROM users
+        WHERE users.installation_id = #{table_name}.id
+        LIMIT 1
+      )
+    SQL
+
+    change_column_null table_name, :user_id, false
+  end
+end

--- a/db/migrate/20150810183703_move_attribute_mappers_to_installations.rb
+++ b/db/migrate/20150810183703_move_attribute_mappers_to_installations.rb
@@ -1,0 +1,28 @@
+class MoveAttributeMappersToInstallations < ActiveRecord::Migration
+  def up
+    remove_column :attribute_mappers, :user_id
+  end
+
+  def down
+    add_column :attribute_mappers, :user_id, :integer
+
+    update(<<-SQL)
+      UPDATE attribute_mappers
+      SET user_id = (
+        SELECT users.id
+        FROM users
+        INNER JOIN installations
+          ON installations.id = users.installation_id
+        LEFT JOIN jobvite_connections
+          ON jobvite_connections.installation_id = installations.id
+        LEFT JOIN net_suite_connections
+          ON net_suite_connections.installation_id = installations.id
+        WHERE attribute_mappers.id = jobvite_connections.attribute_mapper_id
+          OR attribute_mappers.id = net_suite_connections.attribute_mapper_id
+        LIMIT 1
+      )
+    SQL
+
+    change_column_null :attribute_mappers, :user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,18 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150730135326) do
+ActiveRecord::Schema.define(version: 20150810183703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "attribute_mappers", force: true do |t|
-    t.integer  "user_id",    null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
-  add_index "attribute_mappers", ["user_id"], name: "index_attribute_mappers_on_user_id", using: :btree
 
   create_table "delayed_jobs", force: true do |t|
     t.integer  "priority",   default: 0, null: false
@@ -65,40 +62,47 @@ ActiveRecord::Schema.define(version: 20150730135326) do
     t.string   "secret_key"
     t.string   "name"
     t.boolean  "found_namely_field", default: false, null: false
-    t.integer  "user_id",                            null: false
+    t.integer  "installation_id",                    null: false
   end
 
-  add_index "greenhouse_connections", ["user_id"], name: "index_greenhouse_connections_on_user_id", using: :btree
+  add_index "greenhouse_connections", ["installation_id"], name: "index_greenhouse_connections_on_installation_id", using: :btree
 
   create_table "icims_connections", force: true do |t|
     t.datetime "created_at",                         null: false
     t.datetime "updated_at",                         null: false
     t.string   "username"
-    t.integer  "user_id",                            null: false
     t.integer  "customer_id"
     t.boolean  "found_namely_field", default: false, null: false
     t.string   "key"
     t.string   "api_key"
+    t.integer  "installation_id",                    null: false
   end
 
-  add_index "icims_connections", ["user_id"], name: "index_icims_connections_on_user_id", using: :btree
+  add_index "icims_connections", ["installation_id"], name: "index_icims_connections_on_installation_id", using: :btree
+
+  create_table "installations", force: true do |t|
+    t.string   "subdomain",  null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "installations", ["subdomain"], name: "index_installations_on_subdomain", unique: true, using: :btree
 
   create_table "jobvite_connections", force: true do |t|
     t.string   "api_key"
     t.string   "secret"
-    t.integer  "user_id",                                         null: false
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
     t.string   "hired_workflow_state", default: "Offer Accepted", null: false
     t.boolean  "found_namely_field",   default: false,            null: false
     t.integer  "attribute_mapper_id"
+    t.integer  "installation_id",                                 null: false
   end
 
   add_index "jobvite_connections", ["attribute_mapper_id"], name: "index_jobvite_connections_on_attribute_mapper_id", using: :btree
-  add_index "jobvite_connections", ["user_id"], name: "index_jobvite_connections_on_user_id", using: :btree
+  add_index "jobvite_connections", ["installation_id"], name: "index_jobvite_connections_on_installation_id", using: :btree
 
   create_table "net_suite_connections", force: true do |t|
-    t.integer  "user_id"
     t.string   "instance_id"
     t.string   "authorization"
     t.datetime "created_at"
@@ -106,10 +110,11 @@ ActiveRecord::Schema.define(version: 20150730135326) do
     t.boolean  "found_namely_field",  default: false, null: false
     t.string   "subsidiary_id"
     t.integer  "attribute_mapper_id"
+    t.integer  "installation_id",                     null: false
   end
 
   add_index "net_suite_connections", ["attribute_mapper_id"], name: "index_net_suite_connections_on_attribute_mapper_id", using: :btree
-  add_index "net_suite_connections", ["user_id"], name: "index_net_suite_connections_on_user_id", using: :btree
+  add_index "net_suite_connections", ["installation_id"], name: "index_net_suite_connections_on_installation_id", using: :btree
 
   create_table "users", force: true do |t|
     t.datetime "created_at",                                          null: false
@@ -122,6 +127,9 @@ ActiveRecord::Schema.define(version: 20150730135326) do
     t.string   "last_name"
     t.datetime "access_token_expiry", default: '1970-01-01 00:00:00', null: false
     t.string   "email"
+    t.integer  "installation_id",                                     null: false
   end
+
+  add_index "users", ["installation_id"], name: "index_users_on_installation_id", using: :btree
 
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :attribute_mapper do
-    user
   end
 
   factory :field_mapping do
@@ -10,7 +9,7 @@ FactoryGirl.define do
   end
 
   factory :net_suite_connection, :class => 'NetSuite::Connection' do
-    user
+    installation
 
     trait :connected do
       instance_id "123xy"
@@ -23,7 +22,7 @@ FactoryGirl.define do
   end
 
   factory :icims_connection, class: "Icims::Connection" do
-    user
+    installation
 
     trait :connected do
       customer_id 2187
@@ -37,7 +36,7 @@ FactoryGirl.define do
   end
 
   factory :jobvite_connection, class: "Jobvite::Connection" do
-    user
+    installation
 
     trait :connected do
       api_key "MY_API_KEY"
@@ -51,7 +50,7 @@ FactoryGirl.define do
   end
 
   factory :greenhouse_connection, class: "Greenhouse::Connection" do
-    user
+    installation
 
     trait :connected do
       name "MY NAME"
@@ -70,10 +69,19 @@ FactoryGirl.define do
 
   factory :user do
     sequence(:namely_user_id) { |n| "NAMELY-USER-#{n}" }
-    subdomain ENV.fetch("TEST_NAMELY_SUBDOMAIN")
+    subdomain { installation.subdomain }
     access_token ENV.fetch("TEST_NAMELY_ACCESS_TOKEN")
     sequence(:refresh_token) { |n| "refresh-token-#{n}" }
     access_token_expiry { 15.minutes.from_now }
     email "integrationlover@example.com"
+    association :installation, factory: :fixed_subdomain_installation
+  end
+
+  factory :installation do
+    sequence(:subdomain) { |n| "subdomain#{n}" }
+
+    factory :fixed_subdomain_installation do
+      subdomain ENV.fetch("TEST_NAMELY_SUBDOMAIN")
+    end
   end
 end

--- a/spec/features/user_deletes_greenhouse_connection_spec.rb
+++ b/spec/features/user_deletes_greenhouse_connection_spec.rb
@@ -6,7 +6,7 @@ feature "User deletes Greenhouse connection" do
     create(
       :greenhouse_connection,
       :connected,
-      user: user,
+      installation: user.installation,
       found_namely_field: true,
     )
 

--- a/spec/features/user_deletes_icims_connection_spec.rb
+++ b/spec/features/user_deletes_icims_connection_spec.rb
@@ -6,7 +6,7 @@ feature "User deletes iCIMS connection" do
     create(
       :icims_connection,
       :connected,
-      user: user,
+      installation: user.installation,
       found_namely_field: true,
     )
 

--- a/spec/features/user_deletes_jobvite_connection_spec.rb
+++ b/spec/features/user_deletes_jobvite_connection_spec.rb
@@ -6,7 +6,7 @@ feature "User deletes Jobvite connection" do
     create(
       :jobvite_connection,
       :connected,
-      user: user,
+      installation: user.installation,
       found_namely_field: true,
     )
 

--- a/spec/features/user_deletes_net_suite_connection_spec.rb
+++ b/spec/features/user_deletes_net_suite_connection_spec.rb
@@ -3,7 +3,12 @@ require "rails_helper"
 feature "user deletes NetSuite connection" do
   scenario "successfully" do
     user = create(:user)
-    create(:net_suite_connection, :connected, :with_namely_field, user: user)
+    create(
+      :net_suite_connection,
+      :connected,
+      :with_namely_field,
+      installation: user.installation
+    )
 
     visit dashboard_path(as: user)
 

--- a/spec/features/user_imports_jobvite_candidates_spec.rb
+++ b/spec/features/user_imports_jobvite_candidates_spec.rb
@@ -67,8 +67,8 @@ feature "User imports jobvite candidates" do
     user = create(:user)
     create(
       :jobvite_connection,
-      user: user,
       api_key: ENV.fetch("TEST_JOBVITE_KEY"),
+      installation: user.installation,
       secret: ENV.fetch("TEST_JOBVITE_SECRET"),
     )
 
@@ -99,8 +99,8 @@ feature "User imports jobvite candidates" do
     create(
       :jobvite_connection,
       api_key: ENV.fetch("TEST_JOBVITE_KEY"),
+      installation: user.installation,
       secret: ENV.fetch("TEST_JOBVITE_SECRET"),
-      user: user
     )
 
     visit dashboard_path(as: user)

--- a/spec/features/user_tries_to_import_icims_person_again_spec.rb
+++ b/spec/features/user_tries_to_import_icims_person_again_spec.rb
@@ -49,9 +49,9 @@ feature "user tries to import icims person again" do
       create(
         :icims_connection,
         :with_namely_field,
-        key: "KEY",
         customer_id: 2187,
-        user: user,
+        installation: user.installation,
+        key: "KEY",
         username: "USERNAME",
       )
     end

--- a/spec/features/user_visits_dashboard_spec.rb
+++ b/spec/features/user_visits_dashboard_spec.rb
@@ -14,7 +14,7 @@ feature "User visits their dashboard" do
     create(
       :jobvite_connection,
       :connected,
-      user: user,
+      installation: user.installation,
       found_namely_field: false,
     )
 
@@ -31,7 +31,7 @@ feature "User visits their dashboard" do
       create(
         :jobvite_connection,
         :connected,
-        user: user,
+        installation: user.installation,
         found_namely_field: false,
       )
 
@@ -55,7 +55,7 @@ feature "User visits their dashboard" do
       create(
         :jobvite_connection,
         :connected,
-        user: user,
+        installation: user.installation,
         found_namely_field: true,
       )
 
@@ -78,7 +78,7 @@ feature "User visits their dashboard" do
       create(
         :icims_connection,
         :connected,
-        user: user,
+        installation: user.installation,
         found_namely_field: false,
       )
 
@@ -102,7 +102,7 @@ feature "User visits their dashboard" do
       connection = create(
         :icims_connection,
         :connected,
-        user: user,
+        installation: user.installation,
         found_namely_field: true,
       )
 
@@ -126,7 +126,7 @@ feature "User visits their dashboard" do
       create(
         :greenhouse_connection,
         :connected,
-        user: user,
+        installation: user.installation,
         found_namely_field: false,
       )
 
@@ -149,7 +149,7 @@ feature "User visits their dashboard" do
       connection = create(
         :greenhouse_connection,
         :connected,
-        user: user,
+        installation: user.installation,
         found_namely_field: true,
       )
 
@@ -173,7 +173,7 @@ feature "User visits their dashboard" do
       create(
         :net_suite_connection,
         :connected,
-        user: user,
+        installation: user.installation,
         found_namely_field: false,
       )
 
@@ -196,7 +196,7 @@ feature "User visits their dashboard" do
       create(
         :net_suite_connection,
         :connected,
-        user: user,
+        installation: user.installation,
         found_namely_field: true,
       )
 

--- a/spec/models/attribute_mapper_factory_spec.rb
+++ b/spec/models/attribute_mapper_factory_spec.rb
@@ -23,8 +23,7 @@ describe AttributeMapperFactory do
 
     context "without an existing attribute mapper" do
       it "saves a new attribute mapper with the given defaults" do
-        user = create(:user)
-        connection = user.net_suite_connection
+        connection = create(:net_suite_connection)
         factory = AttributeMapperFactory.new(
           attribute_mapper: nil,
           connection: connection
@@ -33,7 +32,6 @@ describe AttributeMapperFactory do
         result = factory.build_with_defaults("firstName" => "first_name")
 
         expect(connection.reload.attribute_mapper_id).to eq(result.id)
-        expect(result.user).to eq(user)
         expect(mapped_fields_for(result)).to eq([%w(firstName first_name)])
       end
     end

--- a/spec/models/attribute_mapper_spec.rb
+++ b/spec/models/attribute_mapper_spec.rb
@@ -1,21 +1,12 @@
 require "rails_helper"
 
 describe AttributeMapper do
-  describe "validations" do
-    it { should validate_presence_of(:user) }
-  end
-
   describe "associations" do
-    it { should belong_to(:user) }
     it { should have_many(:field_mappings).dependent(:destroy) }
   end
 
   describe "#build_field_mappings" do
-    let(:attribute_mapper) do
-      AttributeMapper.new(
-        user: create(:user)
-      )
-    end
+    let(:attribute_mapper) { AttributeMapper.new }
 
     let(:default_field_mapping) do
       {
@@ -49,46 +40,6 @@ describe AttributeMapper do
       expect(
         attribute_mapper.field_mappings.reject(&:persisted?)
       ).to be_empty
-    end
-  end
-
-  describe "#namely_fields" do
-    it "returns mappable fields from a Namely connection" do
-      ["single_select", "short_text", "long_text", "number"]
-      models = [
-        double(name: "first_name", label: "First name", type: "text"),
-        double(name: "last_name", label: "Last name", type: "longtext"),
-        double(name: "gender", label: "Gender", type: "select"),
-        double(name: "email", label: "Email", type: "email"),
-        double(name: "job_title", label: "Job title", type: "referencehistory"),
-        double(name: "user_status", label: "Status", type: "referenceselect"),
-        double(name: "start_date", label: "Started", type: "date"),
-        stub_profile_field(type: "address"),
-        stub_profile_field(type: "checkboxes"),
-        stub_profile_field(type: "file"),
-        stub_profile_field(type: "image"),
-        stub_profile_field(type: "salary"),
-      ]
-      fields = double("fields", all: models)
-      user = build_stubbed(:user)
-      allow(user).to receive(:namely_fields).and_return(fields)
-      attribute_mapper = AttributeMapper.new(user: user)
-
-      result = attribute_mapper.namely_fields
-
-      expect(result).to eq([
-        ["First name", "first_name"],
-        ["Last name", "last_name"],
-        ["Gender", "gender"],
-        ["Email", "email"],
-        ["Job title", "job_title"],
-        ["Status", "user_status"],
-        ["Started", "start_date"],
-      ])
-    end
-
-    def stub_profile_field(type:)
-      double(name: type, label: "#{type} field", type: type)
     end
   end
 

--- a/spec/models/authentication_notifier_spec.rb
+++ b/spec/models/authentication_notifier_spec.rb
@@ -5,7 +5,7 @@ describe AuthenticationNotifier do
     it "translates to a proper name" do
       notifier = AuthenticationNotifier.new(
         integration_id: "icims",
-        user: user_spy
+        installation: installation_spy
       )
 
       expect(notifier.integration_name).to eq("iCIMS")
@@ -16,28 +16,29 @@ describe AuthenticationNotifier do
     it "logs the exception" do
       notifier = AuthenticationNotifier.new(
         integration_id: integration_id_stub,
-        user: user_spy
+        installation: installation_spy
       )
       exception = Unauthorized.new(Unauthorized::DEFAULT_MESSAGE)
 
       expect(Rails.logger).to receive(:error).with(
         "#{exception.class} error #{exception.message} for " \
-        "user_id: #{user_spy.id} with #{notifier.integration_name}"
+        "installation_id: #{installation_spy.id} " \
+        "with #{notifier.integration_name}"
       )
 
       notifier.log_and_notify_of_unauthorized_exception(exception)
     end
 
-    it "tells User to send_connection_notification" do
+    it "tells installation to send_connection_notification" do
       exception = Unauthorized.new(Unauthorized::DEFAULT_MESSAGE)
-      user = user_spy
+      installation = installation_spy
 
       AuthenticationNotifier.new(
         integration_id: integration_id_stub,
-        user: user
+        installation: installation
       ).log_and_notify_of_unauthorized_exception(exception)
 
-      expect(user).to have_received(
+      expect(installation).to have_received(
         :send_connection_notification
       ).with(integration_id: integration_id_stub, message: exception.message)
     end
@@ -47,7 +48,7 @@ describe AuthenticationNotifier do
     "icims"
   end
 
-  def user_spy
-    instance_spy(User, id: 1)
+  def installation_spy
+    instance_spy(Installation, id: 1)
   end
 end

--- a/spec/models/greenhouse/connection_spec.rb
+++ b/spec/models/greenhouse/connection_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe Greenhouse::Connection, :type => :model do
   describe "associations" do
     subject { build(:greenhouse_connection) }
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to belong_to(:installation) }
     it { is_expected.to validate_uniqueness_of(:secret_key) }
   end
 

--- a/spec/models/icims/authorized_request_spec.rb
+++ b/spec/models/icims/authorized_request_spec.rb
@@ -103,7 +103,9 @@ describe Icims::AuthorizedRequest do
 
     context "an authentication error is returned" do
       it "sends an invalid authentication message" do
-        connection = build_connection
+        user = build(:user)
+        installation = build(:installation, users: [user])
+        connection = build_connection(installation: installation)
         request = build_authorized_request(connection: connection)
         stub_request(
           :post,
@@ -116,7 +118,6 @@ describe Icims::AuthorizedRequest do
 
         mail = double(ConnectionMailer, deliver: true)
         exception = Unauthorized.new("401 Unauthorized")
-        user = connection.user
         allow(ConnectionMailer).
           to receive(:authentication_notification).
           with(
@@ -139,8 +140,8 @@ describe Icims::AuthorizedRequest do
     described_class.new(connection: connection, request: request)
   end
 
-  def build_connection
-    build(:icims_connection, :connected)
+  def build_connection(*attributes)
+    build(:icims_connection, :connected, *attributes)
   end
 
   def errors

--- a/spec/models/icims/client_spec.rb
+++ b/spec/models/icims/client_spec.rb
@@ -25,7 +25,7 @@ describe Icims::Client do
             "icims_connection",
             api_url: icims_customer_api_url,
             key: "MY_KEY",
-            user: user_double,
+            installation: installation_double,
             username: "USERNAME",
           )
           client = described_class.new(connection)
@@ -56,7 +56,7 @@ describe Icims::Client do
             "icims_connection",
             api_url: icims_customer_api_url,
             key: "MY_KEY",
-            user: user_double,
+            installation: installation_double,
             username: "USERNAME",
           )
 
@@ -76,7 +76,7 @@ describe Icims::Client do
           "icims_connection",
           api_url: icims_customer_api_url,
           key: "MY_KEY",
-          user: user_double,
+          installation: installation_double,
           username: "USERNAME",
         )
 
@@ -105,7 +105,7 @@ describe Icims::Client do
     }.merge(values).to_json
   end
 
-  def user_double
-    build_stubbed(:user)
+  def installation_double
+    build_stubbed(:installation)
   end
 end

--- a/spec/models/icims/connection_spec.rb
+++ b/spec/models/icims/connection_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 describe Icims::Connection do
   describe "associations" do
     subject { build(:icims_connection) }
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to belong_to(:installation) }
     it { is_expected.to validate_uniqueness_of(:api_key) }
   end
 

--- a/spec/models/importer_spec.rb
+++ b/spec/models/importer_spec.rb
@@ -4,10 +4,7 @@ describe Importer do
   describe "#import" do
     context "with a connected" do
       it "passes hired candidates to the NamelyImporter and set the status" do
-        user = double(
-          "user",
-          namely_connection: double("Namely::Connection"),
-        )
+        namely_connection = double("Namely::Connection")
         connection = double("connection", connected?: true)
         recent_hires = [double("hire")]
         client = double("client", recent_hires: recent_hires)
@@ -20,7 +17,7 @@ describe Importer do
           client: client,
           connection: connection,
           namely_importer: namely_importer,
-          user: user,
+          namely_connection: namely_connection,
         )
 
         status = import.import
@@ -33,10 +30,7 @@ describe Importer do
 
     context "when the request fails" do
       it "sets the status to error message" do
-        user = double(
-          "user",
-          namely_connection: double("Namely::Connection"),
-        )
+        namely_connection = double("Namely::Connection")
         connection = double("connection", connected?: true)
         client = double("client", class: Icims::Client)
         allow(client).
@@ -47,7 +41,7 @@ describe Importer do
           client: client,
           connection: connection,
           namely_importer: namely_importer,
-          user: user,
+          namely_connection: namely_connection
         )
 
         status = import.import
@@ -60,10 +54,7 @@ describe Importer do
 
     context "when the Namely API request fails" do
       it "sets the status to the Namely error message" do
-        user = double(
-          "user",
-          namely_connection: double("Namely::Connection"),
-        )
+        namely_connection = double("Namely::Connection")
         recent_hires = [double("hire")]
         connection = double("connection", connected?: true)
         client = double(
@@ -79,7 +70,7 @@ describe Importer do
           client: client,
           connection: connection,
           namely_importer: namely_importer,
-          user: user,
+          namely_connection: namely_connection
         )
 
         status = import.import
@@ -92,15 +83,12 @@ describe Importer do
 
     context "with a disconnected" do
       it "does nothing and sets an appropriate status" do
-        user = double(
-          "user",
-          namely_connection: double("Namely::Connection"),
-        )
+        namely_connection = double("Namely::Connection")
         importer = described_class.new(
           client: double("client"),
           connection: double("connection", connected?: false),
           namely_importer: double("namely_importer"),
-          user: user,
+          namely_connection: namely_connection
         )
         status = nil
 

--- a/spec/models/installation_spec.rb
+++ b/spec/models/installation_spec.rb
@@ -1,0 +1,159 @@
+require "rails_helper"
+
+describe Installation do
+  describe "validations" do
+    subject { create(:installation) }
+    it { is_expected.to validate_presence_of(:subdomain) }
+    it { is_expected.to validate_uniqueness_of(:subdomain) }
+  end
+
+  describe "associations" do
+    it { is_expected.to have_many(:users).dependent(:destroy) }
+    it { is_expected.to have_one(:greenhouse_connection).dependent(:destroy) }
+    it { is_expected.to have_one(:icims_connection).dependent(:destroy) }
+    it { is_expected.to have_one(:jobvite_connection).dependent(:destroy) }
+    it { is_expected.to have_one(:net_suite_connection).dependent(:destroy) }
+  end
+
+  describe ".ready_to_sync_with" do
+    it "returns installations ready to connect to the given integration" do
+      create_installation(
+        :net_suite_connection,
+        :connected,
+        :with_namely_field,
+        subdomain: "ready-with-given-service"
+      )
+      create_installation(
+        :net_suite_connection,
+        :connected,
+        subdomain: "connected-without-field"
+      )
+      create_installation(
+        :net_suite_connection,
+        subdomain: "disconnected"
+      )
+      create(:installation, subdomain: "uninitialized")
+      create_installation(
+        :greenhouse_connection,
+        :connected,
+        :with_namely_field,
+        subdomain: "ready-with-different-service"
+      )
+
+      result = Installation.ready_to_sync_with(:net_suite)
+
+      expect(result.map(&:subdomain)).to eq(%w(ready-with-given-service))
+    end
+
+    def create_installation(factory, *traits, subdomain:)
+      installation = create(:installation, subdomain: subdomain)
+      create(factory, *traits, installation: installation)
+    end
+  end
+
+  describe "#jobvite_connection" do
+    it "returns the existing Jobvite::Connection when one exists" do
+      installation = create(:installation)
+
+      jobvite_connection = create(
+        :jobvite_connection,
+        installation: installation
+      )
+
+      expect(installation.jobvite_connection).to eq jobvite_connection
+    end
+
+    it "creates a new Jobvite::Connection when one doesn't exist" do
+      installation = create(:installation)
+
+      jobvite_connection = installation.jobvite_connection
+
+      expect(jobvite_connection).to be_a Jobvite::Connection
+      expect(jobvite_connection).to be_persisted
+      expect(jobvite_connection.installation_id).to eq installation.id
+    end
+  end
+
+  describe "#net_suite_connection" do
+    context "with an existing connection" do
+      it "returns the existing connection" do
+        installation = create(:installation)
+
+        net_suite_connection = create(
+          :net_suite_connection,
+          installation: installation
+        )
+
+        expect(installation.net_suite_connection).to eq net_suite_connection
+      end
+    end
+
+    context "with no existing connection" do
+      it "creates a new connection" do
+        installation = create(:installation)
+
+        net_suite_connection = installation.net_suite_connection
+
+        expect(net_suite_connection).to be_a NetSuite::Connection
+        expect(net_suite_connection).to be_persisted
+        expect(net_suite_connection.installation_id).to eq installation.id
+      end
+    end
+  end
+
+  describe "#send_connection_notification" do
+    it "delegates to each users" do
+      users = [build_stubbed(:user), build_stubbed(:user)]
+      stub_each(users, :send_connection_notification)
+      message = "Whoops"
+      installation = Installation.new(users: users)
+
+      installation.send_connection_notification(
+        integration_id: "icims",
+        message: message
+      )
+
+      users.each do |user|
+        expect(user).
+          to have_received(:send_connection_notification).
+          with(integration_id: "icims", message: message)
+      end
+    end
+  end
+
+  describe "#namely_connection" do
+    it "delegates to its first user" do
+      users = [build_stubbed(:user), build_stubbed(:user)]
+      namely_connection = double(namely_connection)
+      allow(users.first).
+        to receive(:namely_connection).
+        and_return(namely_connection)
+      installation = Installation.new(users: users)
+
+      result = installation.namely_connection
+
+      expect(result).to eq(namely_connection)
+    end
+  end
+
+  describe "#namely_profiles" do
+    it "delegates to its first user" do
+      users = [build_stubbed(:user), build_stubbed(:user)]
+      namely_profiles = double(namely_profiles)
+      allow(users.first).
+        to receive(:namely_profiles).
+        and_return(namely_profiles)
+      installation = Installation.new(users: users)
+
+      result = installation.namely_profiles
+
+      expect(result).to eq(namely_profiles)
+    end
+  end
+
+  def stub_each(array, method_name)
+    array.each do |item|
+      allow(item).to receive(method_name)
+    end
+  end
+end

--- a/spec/models/jobvite/client_spec.rb
+++ b/spec/models/jobvite/client_spec.rb
@@ -25,7 +25,7 @@ describe Jobvite::Client do
           api_key: "MY_API_KEY",
           hired_workflow_state: "Hired",
           secret: "MY_SECRET",
-          user: user_double,
+          installation: installation_double,
         )
 
         client = described_class.new(connection)
@@ -57,7 +57,7 @@ describe Jobvite::Client do
             api_key: "MY_API_KEY",
             hired_workflow_state: "Hired",
             secret: "MY_SECRET",
-            user: user_double,
+            installation: installation_double,
           )
 
           client = described_class.new(connection)
@@ -105,7 +105,7 @@ describe Jobvite::Client do
           api_key: "MY_API_KEY",
           hired_workflow_state: "Offer Accepted",
           secret: "MY_SECRET",
-          user: user_double,
+          installation: installation_double,
         )
 
         client = described_class.new(connection)
@@ -129,7 +129,7 @@ describe Jobvite::Client do
           api_key: "MY_API_KEY",
           hired_workflow_state: "Offer Accepted",
           secret: "MY_SECRET",
-          user: user_double,
+          installation: installation_double,
         )
 
         client = described_class.new(connection)
@@ -154,38 +154,29 @@ describe Jobvite::Client do
             JSON
           )
 
-        user = user_double
+        installation = installation_double
         connection = double(
           "jobvite_connection",
           api_key: "MY_API_KEY",
           hired_workflow_state: "Offer Accepted",
           secret: "MY_SECRET",
-          user: user,
+          installation: installation,
         )
 
         client = Jobvite::Client.new(connection)
 
-        mail = double(ConnectionMailer, deliver: true)
         exception = Unauthorized.new("An error message")
-        allow(ConnectionMailer).
-          to receive(:authentication_notification).
-          with(
-            email: user.email,
-            integration_id: "jobvite",
-            message: exception.message
-          ).
-          and_return(mail)
+        allow(installation).to receive(:send_connection_notification)
 
-        expect { client.recent_hires }.to raise_error(
-          Unauthorized
-        )
-        expect(mail).to have_received(:deliver)
+        expect { client.recent_hires }.to raise_error(Unauthorized)
+        expect(installation).to have_received(:send_connection_notification).
+          with(integration_id: "jobvite", message: exception.message)
       end
     end
   end
 
-  def user_double
-    build_stubbed(:user)
+  def installation_double
+    build_stubbed(:installation)
   end
 
   def sample_response(values = {})

--- a/spec/models/jobvite/connection_spec.rb
+++ b/spec/models/jobvite/connection_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 describe Jobvite::Connection do
   describe "associations" do
-    it { should belong_to(:attribute_mapper).dependent(:destroy) }
-    it { should belong_to(:user) }
+    it { is_expected.to belong_to(:attribute_mapper).dependent(:destroy) }
+    it { is_expected.to belong_to(:installation) }
   end
 
   describe "validations" do
-    it { should validate_presence_of(:hired_workflow_state) }
+    it { is_expected.to validate_presence_of(:hired_workflow_state) }
   end
 
   describe "#connected?" do
@@ -26,7 +26,12 @@ describe Jobvite::Connection do
 
   describe "#sync" do
     it "uses the importer" do
-      jobvite_connection = create(:jobvite_connection)
+      user = create(:user)
+      installation = user.installation
+      jobvite_connection = create(
+        :jobvite_connection,
+        installation: installation
+      )
       candidate = double("candidate")
       failure = double("failed_candidate_import", success?: false)
       success = double("successful_candidate_import", success?: true)
@@ -60,13 +65,6 @@ describe Jobvite::Connection do
           %w(gender gender),
         ])
     end
-  end
-
-  def stub_namely_connection(user, field_names:)
-    fields = field_names.map { |name| double("field", name: name) }
-    fields_collection = double("fields", all: fields)
-    namely_connection = double("namely_connection", fields: fields_collection)
-    allow(user).to receive(:namely_connection).and_return(namely_connection)
   end
 
   def mapped_fields_for(attribute_mapper)

--- a/spec/models/net_suite/client_spec.rb
+++ b/spec/models/net_suite/client_spec.rb
@@ -10,7 +10,7 @@ describe NetSuite::Client do
 
       ClimateControl.modify env do
         stub_request(:post, /.*/)
-        client = NetSuite::Client.from_env(build_stubbed(:user))
+        client = NetSuite::Client.from_env
 
         client.create_instance({})
 
@@ -27,7 +27,6 @@ describe NetSuite::Client do
     it "sets element authorization" do
       stub_request(:post, /.*/)
       client = NetSuite::Client.new(
-        user: build_stubbed(:user),
         user_secret: "user-secret",
         organization_secret: "org-secret",
       )
@@ -76,7 +75,6 @@ describe NetSuite::Client do
           to_return(status: 200, body: instance.to_json)
 
         client = NetSuite::Client.new(
-          user: build_stubbed(:user),
           user_secret: "user-secret",
           organization_secret: "org-secret"
         )
@@ -103,7 +101,6 @@ describe NetSuite::Client do
           to_return(status: 400, body: { message: error }.to_json)
 
         client = NetSuite::Client.new(
-          user: build_stubbed(:user),
           user_secret: "x",
           organization_secret: "x"
         )
@@ -126,10 +123,7 @@ describe NetSuite::Client do
         ).
           to_return(status: 401, body: { message: error }.to_json)
 
-        user = build_stubbed(:user)
-
         client = NetSuite::Client.new(
-          user: user,
           user_secret: "x",
           organization_secret: "x"
         )
@@ -167,7 +161,6 @@ describe NetSuite::Client do
           to_return(status: 200, body: employee.to_json)
 
         client = NetSuite::Client.new(
-          user: build_stubbed(:user),
           user_secret: "user-secret",
           organization_secret: "org-secret",
           element_secret: "element-secret"
@@ -218,7 +211,6 @@ describe NetSuite::Client do
           to_return(status: 200, body: employee.to_json)
 
         client = NetSuite::Client.new(
-          user: build_stubbed(:user),
           user_secret: "user-secret",
           organization_secret: "org-secret",
           element_secret: "element-secret"
@@ -293,7 +285,6 @@ describe NetSuite::Client do
 
   def client
     NetSuite::Client.new(
-      user: build_stubbed(:user),
       user_secret: "user-secret",
       organization_secret: "org-secret",
       element_secret: "element-secret"

--- a/spec/models/net_suite/connection_spec.rb
+++ b/spec/models/net_suite/connection_spec.rb
@@ -7,8 +7,8 @@ describe NetSuite::Connection do
   end
 
   describe "associations" do
-    it { should belong_to(:attribute_mapper).dependent(:destroy) }
-    it { should belong_to(:user) }
+    it { is_expected.to belong_to(:attribute_mapper).dependent(:destroy) }
+    it { is_expected.to belong_to(:installation) }
   end
 
   describe "#connected?" do
@@ -65,7 +65,7 @@ describe NetSuite::Connection do
     it "builds and saves an attribute mapper" do
       connection = NetSuite::Connection.new(
         subsidiary_id: "x",
-        user: create(:user)
+        installation: create(:installation)
       )
 
       connection.save!
@@ -107,7 +107,7 @@ describe NetSuite::Connection do
       namely_profiles = double(:namely_profiles)
       client = stub_client(authorization: "x")
       connection = create(:net_suite_connection, authorization: "x")
-      allow(connection.user).
+      allow(connection.installation).
         to receive(:namely_profiles).
         and_return(namely_profiles)
       results = double(:results)

--- a/spec/models/net_suite/employee_fields_loader_spec.rb
+++ b/spec/models/net_suite/employee_fields_loader_spec.rb
@@ -32,7 +32,6 @@ describe NetSuite::EmployeeFieldsLoader do
       request = NetSuite::Client.new(
         element_secret: "element-secret",
         organization_secret: "org-secret",
-        user: create(:user),
         user_secret: "user-secret",
       ).request
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -30,6 +30,7 @@ describe Session do
         )
 
         user = session.user
+        installation = user.installation
 
         expect(user.namely_user_id).to eq "a-namely-user"
         expect(user.subdomain).to eq "my-subdomain"
@@ -40,6 +41,8 @@ describe Session do
         expect(user.first_name).to eq "Eugene"
         expect(user.last_name).to eq "Belford"
         expect(user).to be_persisted
+        expect(installation.subdomain).to eq "my-subdomain"
+        expect(installation).to be_persisted
         expect(authenticator).to have_received(:retrieve_tokens).with("my-code")
         expect(authenticator).to have_received(:current_user).with("my-access-token")
       end
@@ -48,12 +51,15 @@ describe Session do
     context "for a returning User" do
       it "updates and returns a User" do
         expiry_time = Time.current + expiry_time_in_seconds.seconds
+        subdomain = "my-subdomain"
+        installation = create(:installation, subdomain: subdomain)
         existing_user = create(
           :user,
           namely_user_id: "a-namely-user",
-          subdomain: "my-subdomain",
+          subdomain: subdomain,
           access_token: "old-access-token",
           refresh_token: "old-refresh-token",
+          installation: installation,
         )
         authenticator = authenticator_double(
           namely_user_id: existing_user.namely_user_id,
@@ -64,7 +70,7 @@ describe Session do
         session = described_class.new(
           authenticator,
           code: "my-code",
-          subdomain: "my-subdomain",
+          subdomain: subdomain,
         )
 
         user = session.user

--- a/spec/requests/greenhouse_statuses_spec.rb
+++ b/spec/requests/greenhouse_statuses_spec.rb
@@ -7,8 +7,13 @@ describe "Greenhouse new candidate" do
       subdomain: ENV["TEST_NAMELY_SUBDOMAIN"],
     }
   end
-  let(:connection) do 
-    create(:greenhouse_connection, :with_namely_field, name: "myhook") 
+  let(:connection) do
+    create(
+      :greenhouse_connection,
+      :with_namely_field,
+      installation: create(:user).installation,
+      name: "myhook"
+    )
   end
 
   before do

--- a/spec/requests/icims_statuses_spec.rb
+++ b/spec/requests/icims_statuses_spec.rb
@@ -63,9 +63,9 @@ describe "iCIMS new candidate" do
     create(
       :icims_connection,
       :with_namely_field,
-      key: "KEY",
       customer_id: 2187,
-      user: user,
+      installation: user.installation,
+      key: "KEY",
       username: "USERNAME",
     )
   end

--- a/spec/services/greenhouse/candidate_import_assistant_spec.rb
+++ b/spec/services/greenhouse/candidate_import_assistant_spec.rb
@@ -46,7 +46,13 @@ describe Greenhouse::CandidateImportAssistant do
       CandidateImporter,
       connection: double(:connection),
       params: {},
-      user: double(:user, namely_fields: double(:fields, all: true))
+      installation: double(
+        :installation,
+        namely_connection: double(
+          :namely_connection,
+          fields: double(:fields, all: true)
+        )
+      )
     )
   end
 

--- a/spec/services/user_check_namely_field_spec.rb
+++ b/spec/services/user_check_namely_field_spec.rb
@@ -67,12 +67,12 @@ describe UserCheckNamelyField do
       found_namely_field?: found,
       required_namely_field: required_field,
       update: true,
-      user: stub_user(fields)
+      installation: stub_installation(fields)
     )
   end
 
-  def stub_user(fields)
-    double(:user, namely_connection: stub_namely_connection(fields))
+  def stub_installation(fields)
+    double(:installation, namely_connection: stub_namely_connection(fields))
   end
 
   def stub_namely_connection(fields)


### PR DESCRIPTION
Because:

* Multiple users belong to the same Namely account
* Only one connection can sync for each integration/Namely account

This commit:

* Introduces an invisible installation concept
* Adds users from the same Namely account to the same installation
* Associates connections with installations instead of users

Effects:

* Multiple users on the same Namely account can share connections

https://trello.com/c/W6KqJcez