### PR TITLE
Users can map custom NetSuite fields

### DIFF
--- a/app/models/attribute_mapper_factory.rb
+++ b/app/models/attribute_mapper_factory.rb
@@ -4,7 +4,7 @@ class AttributeMapperFactory
     @connection = connection
   end
 
-  def build_with_defaults(defaults)
+  def build_with_defaults(&defaults)
     @attribute_mapper || assign_attribute_mapper(defaults)
   end
 
@@ -13,7 +13,7 @@ class AttributeMapperFactory
   def assign_attribute_mapper(defaults)
     AttributeMapper.create!.tap do |attribute_mapper|
       @connection.update!(attribute_mapper: attribute_mapper)
-      defaults.each do |integration_field_name, namely_field_name|
+      defaults.call.each do |integration_field_name, namely_field_name|
         attribute_mapper.field_mappings.create!(
           integration_field_name: integration_field_name,
           namely_field_name: namely_field_name

--- a/app/models/field_mapping.rb
+++ b/app/models/field_mapping.rb
@@ -4,7 +4,6 @@ class FieldMapping < ActiveRecord::Base
   validates :attribute_mapper, presence: true
   validates :attribute_mapper_id, presence: true
   validates :integration_field_name, presence: true
-  validates :namely_field_name, presence: true
 
   def integration_key
     integration_field_name.underscore.parameterize("_")

--- a/app/models/jobvite/connection.rb
+++ b/app/models/jobvite/connection.rb
@@ -27,13 +27,15 @@ module Jobvite
 
     def attribute_mapper
       AttributeMapperFactory.new(attribute_mapper: super, connection: self).
-        build_with_defaults(
-          "first_name" => "first_name",
-          "last_name" => "last_name",
-          "email" => "email",
-          "start_date" => "start_date",
-          "gender" => "gender",
-        )
+        build_with_defaults do
+          {
+            "first_name" => "first_name",
+            "last_name" => "last_name",
+            "email" => "email",
+            "start_date" => "start_date",
+            "gender" => "gender",
+          }
+        end
     end
 
     def required_namely_field

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -28,14 +28,7 @@ class NetSuite::Connection < ActiveRecord::Base
 
   def attribute_mapper
     AttributeMapperFactory.new(attribute_mapper: super, connection: self).
-      build_with_defaults(
-        "email" => "email",
-        "firstName" => "first_name",
-        "gender" => "gender",
-        "phone" => "home_phone",
-        "title" => "job_title",
-        "lastName" => "last_name",
-      )
+      build_with_defaults { default_field_mappings }
   end
 
   def ready?
@@ -71,5 +64,32 @@ class NetSuite::Connection < ActiveRecord::Base
       attribute_mapper: attribute_mapper,
       configuration: self
     )
+  end
+
+  def default_field_mappings
+    remote_fields.merge!(premapped_fields)
+  end
+
+  def remote_fields
+    mappable_fields.each_with_object({}) do |profile_field, result|
+      result[profile_field.name] = nil
+    end
+  end
+
+  def mappable_fields
+    client.profile_fields.select do |profile_field|
+      profile_field.type == "text"
+    end
+  end
+
+  def premapped_fields
+    {
+      "email" => "email",
+      "firstName" => "first_name",
+      "gender" => "gender",
+      "phone" => "home_phone",
+      "title" => "job_title",
+      "lastName" => "last_name",
+    }
   end
 end

--- a/app/views/mappings/_field_mapping.html.erb
+++ b/app/views/mappings/_field_mapping.html.erb
@@ -2,7 +2,10 @@
   <td>
     <%= fields.label(
       :namely_field_name,
-      t("integration_fields.#{field_mapping.integration_key}")
+      t(
+        "integration_fields.#{field_mapping.integration_key}",
+        default: field_mapping.integration_field_name.titleize
+      )
     ) %>
   </td>
   <td>

--- a/db/migrate/20150811181537_change_field_mappings_namely_field_name_to_nullable.rb
+++ b/db/migrate/20150811181537_change_field_mappings_namely_field_name_to_nullable.rb
@@ -1,0 +1,12 @@
+class ChangeFieldMappingsNamelyFieldNameToNullable < ActiveRecord::Migration
+  def up
+    change_column_null :field_mappings, :namely_field_name, true
+  end
+
+  def down
+    delete(<<-SQL)
+      DELETE FROM field_mappings WHERE namely_field_name IS NULL
+    SQL
+    change_column_null :field_mappings, :namely_field_name, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150810183703) do
+ActiveRecord::Schema.define(version: 20150811181537) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 20150810183703) do
 
   create_table "field_mappings", force: true do |t|
     t.string   "integration_field_name", null: false
-    t.string   "namely_field_name",      null: false
+    t.string   "namely_field_name"
     t.integer  "attribute_mapper_id",    null: false
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/spec/features/user_connects_net_suite_account_spec.rb
+++ b/spec/features/user_connects_net_suite_account_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 feature "user connects NetSuite account" do
   scenario "successfully" do
     stub_namely_fields("fields_with_net_suite")
+    stub_net_suite_fields
     stub_create_instance(status: 200, body: { id: "123", token: "abcxyz" })
     stub_lookup_subsidiaries(
       status: 200,
@@ -38,6 +39,7 @@ feature "user connects NetSuite account" do
 
   scenario "with updated credentials" do
     stub_namely_fields("fields_with_net_suite")
+    stub_net_suite_fields
     stub_create_instance(status: 200, body: { id: "123", token: "abcxyz" })
     stub_lookup_subsidiaries(
       status: 200,
@@ -82,6 +84,15 @@ feature "user connects NetSuite account" do
       :post,
       "https://api.cloud-elements.com/elements/api-v2/instances"
     ).to_return(status: status, body: JSON.dump(body))
+  end
+
+  def stub_net_suite_fields
+    net_suite_employee =
+      File.read("spec/fixtures/api_responses/net_suite_employee.json")
+    stub_request(
+      :get,
+      %r{.*/elements/api-v2/hubs/erp/employees\?.*}
+    ).to_return(status: 200, body: net_suite_employee)
   end
 
   def stub_lookup_subsidiaries(status:, body:)

--- a/spec/features/user_exports_to_net_suite_spec.rb
+++ b/spec/features/user_exports_to_net_suite_spec.rb
@@ -5,6 +5,8 @@ feature "user exports to net suite" do
     user = create(:user)
     cloud_elements = "https://api.cloud-elements.com/elements/api-v2/hubs/erp"
     subsidiary_url = "#{cloud_elements}/lookups/subsidiary"
+    employee_json =
+      File.read("spec/fixtures/api_responses/net_suite_employee.json")
 
     stub_namely_data("/profiles", "profiles_with_net_suite_fields")
     stub_request(:put, %r{.*api/v1/profiles/.*}).to_return(status: 200)
@@ -17,6 +19,8 @@ feature "user exports to net suite" do
     stub_request(:post, "#{cloud_elements}/employees").
       with(body: /Mickey/).
       to_return(status: 400, body: { "message" => "Bad Data" }.to_json)
+    stub_request(:get, %r{#{cloud_elements}/employees\?pageSize=.*}).
+      to_return(status: 200, body: employee_json)
     stub_namely_fields("fields_with_net_suite")
     stub_request(
       :post,
@@ -39,6 +43,7 @@ feature "user exports to net suite" do
 
     select "Mobile phone", from: t("integration_fields.phone")
     select "Custom field", from: t("integration_fields.email")
+    select "Preferred name", from: "Initials"
     click_on t("attribute_mappings.edit.save")
 
     find(".net-suite-account").click_on t("dashboards.show.export_now")

--- a/spec/fixtures/api_responses/net_suite_employee.json
+++ b/spec/fixtures/api_responses/net_suite_employee.json
@@ -1,0 +1,107 @@
+[
+    {
+        "lastName": "Wolfe",
+        "gender": {
+            "value": "_male"
+        },
+        "isInactive": false,
+        "approvalLimit": 1000000.0,
+        "isSupportRep": true,
+        "purchaseOrderLimit": 10000.0,
+        "title": "VP Sales",
+        "employeeStatus": {
+            "internalId": "3",
+            "name": "Regular - Full Time"
+        },
+        "expenseLimit": 5000.0,
+        "isSalesRep": true,
+        "internalId": "-5",
+        "billPay": false,
+        "dateCreated": 1382425200000,
+        "nextReviewDate": 1438412400000,
+        "officePhone": "(650) 555-9788",
+        "isJobResource": false,
+        "currency": {
+            "internalId": "1",
+            "name": "USD"
+        },
+        "fax": "(650) 555-9788",
+        "department": {
+            "internalId": "11",
+            "name": "Engineering"
+        },
+        "email": "user@example.com",
+        "giveAccess": true,
+        "customFieldList": {
+            "customField": [
+                {
+                    "internalId": "696",
+                    "scriptId": "custentity2",
+                    "value": false
+                },
+                {
+                    "internalId": "3992",
+                    "scriptId": "custentity_2663_payment_method",
+                    "value": false
+                }
+            ]
+        },
+        "approver": {
+            "internalId": "1302",
+            "name": "Mark Jones"
+        },
+        "image": {
+            "internalId": "12446",
+            "name": "AlexWolfe"
+        },
+        "hireDate": 1343804400000,
+        "lastModifiedDate": 1428997975000,
+        "initials": "AW",
+        "homePhone": "(650) 555-9788",
+        "externalId": "entity-5",
+        "workCalendar": {
+            "internalId": "1",
+            "name": "Default Work Calendar"
+        },
+        "entityId": "Alex Wolfe",
+        "purchaseOrderApprover": {
+            "internalId": "1302",
+            "name": "Mark Jones"
+        },
+        "accountNumber": "ADP00001",
+        "birthDate": -433094400000,
+        "subsidiary": {
+            "internalId": "1",
+            "name": "Honeycomb Mfg."
+        },
+        "firstName": "Alex",
+        "employeeType": {
+            "internalId": "1",
+            "name": "Officer"
+        },
+        "mobilePhone": "(650) 555-9788",
+        "phone": "(650) 555-9788",
+        "lastReviewDate": 1408086000000,
+        "globalSubscriptionStatus": {
+            "value": "_softOptIn"
+        },
+        "purchaseOrderApprovalLimit": 1000000.0,
+        "location": {
+            "internalId": "2",
+            "name": "01: San Francisco"
+        },
+        "_class": {
+            "internalId": "15",
+            "name": "Internal"
+        },
+        "supervisor": {
+            "internalId": "1302",
+            "name": "Mark Jones"
+        },
+        "maritalStatus": {
+            "internalId": "2",
+            "name": "Married"
+        },
+        "defaultAddress": "US"
+    }
+]

--- a/spec/models/attribute_mapper_factory_spec.rb
+++ b/spec/models/attribute_mapper_factory_spec.rb
@@ -14,7 +14,7 @@ describe AttributeMapperFactory do
           connection: connection
         )
 
-        result = factory.build_with_defaults({})
+        result = factory.build_with_defaults { {} }
 
         expect(result).to eq(attribute_mapper)
         expect(connection.reload.attribute_mapper.id).to eq(attribute_mapper.id)
@@ -29,7 +29,7 @@ describe AttributeMapperFactory do
           connection: connection
         )
 
-        result = factory.build_with_defaults("firstName" => "first_name")
+        result = factory.build_with_defaults { { "firstName" => "first_name" } }
 
         expect(connection.reload.attribute_mapper_id).to eq(result.id)
         expect(mapped_fields_for(result)).to eq([%w(firstName first_name)])

--- a/spec/models/field_mapping_spec.rb
+++ b/spec/models/field_mapping_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 describe FieldMapping do
   describe "validations" do
     it { should validate_presence_of(:integration_field_name) }
-    it { should validate_presence_of(:namely_field_name) }
     it { should validate_presence_of(:attribute_mapper) }
   end
 


### PR DESCRIPTION
Because:

* Users can create custom fields in NetSuite
* Users can create custom fields in Namely

This commit:

* Downloads an employee as an example
* Uses the employee to determine available fields
* Allows users to map available text fields in NetSuite

https://trello.com/c/Z2SKrJeU