### PR TITLE
Refactor API for field mappings

### DIFF
--- a/app/models/attribute_mapper_factory.rb
+++ b/app/models/attribute_mapper_factory.rb
@@ -4,21 +4,16 @@ class AttributeMapperFactory
     @connection = connection
   end
 
-  def build_with_defaults(&defaults)
-    @attribute_mapper || assign_attribute_mapper(defaults)
+  def build_with_defaults(&block)
+    @attribute_mapper || assign_attribute_mapper(&block)
   end
 
   private
 
-  def assign_attribute_mapper(defaults)
+  def assign_attribute_mapper
     AttributeMapper.create!.tap do |attribute_mapper|
       @connection.update!(attribute_mapper: attribute_mapper)
-      defaults.call.each do |integration_field_name, namely_field_name|
-        attribute_mapper.field_mappings.create!(
-          integration_field_name: integration_field_name,
-          namely_field_name: namely_field_name
-        )
-      end
+      yield attribute_mapper.field_mappings
     end
   end
 end

--- a/app/models/field_mapping.rb
+++ b/app/models/field_mapping.rb
@@ -5,6 +5,12 @@ class FieldMapping < ActiveRecord::Base
   validates :attribute_mapper_id, presence: true
   validates :integration_field_name, presence: true
 
+  def self.map!(field, to: nil)
+    if where(integration_field_name: field).empty?
+      create!(integration_field_name: field, namely_field_name: to)
+    end
+  end
+
   def integration_key
     integration_field_name.underscore.parameterize("_")
   end

--- a/app/models/jobvite/connection.rb
+++ b/app/models/jobvite/connection.rb
@@ -27,14 +27,12 @@ module Jobvite
 
     def attribute_mapper
       AttributeMapperFactory.new(attribute_mapper: super, connection: self).
-        build_with_defaults do
-          {
-            "first_name" => "first_name",
-            "last_name" => "last_name",
-            "email" => "email",
-            "start_date" => "start_date",
-            "gender" => "gender",
-          }
+        build_with_defaults do |mappings|
+          mappings.map! "first_name", to: "first_name"
+          mappings.map! "last_name", to: "last_name"
+          mappings.map! "email", to: "email"
+          mappings.map! "start_date", to: "start_date"
+          mappings.map! "gender", to: "gender"
         end
     end
 

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -28,7 +28,7 @@ class NetSuite::Connection < ActiveRecord::Base
 
   def attribute_mapper
     AttributeMapperFactory.new(attribute_mapper: super, connection: self).
-      build_with_defaults { default_field_mappings }
+      build_with_defaults { |mappings| map_defaults(mappings) }
   end
 
   def ready?
@@ -66,13 +66,14 @@ class NetSuite::Connection < ActiveRecord::Base
     )
   end
 
-  def default_field_mappings
-    remote_fields.merge!(premapped_fields)
+  def map_defaults(mappings)
+    map_standard_fields(mappings)
+    map_remote_fields(mappings)
   end
 
-  def remote_fields
-    mappable_fields.each_with_object({}) do |profile_field, result|
-      result[profile_field.name] = nil
+  def map_remote_fields(mappings)
+    mappable_fields.each do |profile_field|
+      mappings.map! profile_field.name
     end
   end
 
@@ -82,14 +83,12 @@ class NetSuite::Connection < ActiveRecord::Base
     end
   end
 
-  def premapped_fields
-    {
-      "email" => "email",
-      "firstName" => "first_name",
-      "gender" => "gender",
-      "phone" => "home_phone",
-      "title" => "job_title",
-      "lastName" => "last_name",
-    }
+  def map_standard_fields(mappings)
+    mappings.map! "email", to: "email"
+    mappings.map! "firstName", to: "first_name"
+    mappings.map! "gender", to: "gender"
+    mappings.map! "lastName", to: "last_name"
+    mappings.map! "phone", to: "home_phone"
+    mappings.map! "title", to: "job_title"
   end
 end

--- a/spec/models/attribute_mapper_factory_spec.rb
+++ b/spec/models/attribute_mapper_factory_spec.rb
@@ -11,10 +11,10 @@ describe AttributeMapperFactory do
         )
         factory = AttributeMapperFactory.new(
           attribute_mapper: attribute_mapper,
-          connection: connection
+          connection: connection,
         )
 
-        result = factory.build_with_defaults { {} }
+        result = factory.build_with_defaults { |_| }
 
         expect(result).to eq(attribute_mapper)
         expect(connection.reload.attribute_mapper.id).to eq(attribute_mapper.id)
@@ -29,7 +29,12 @@ describe AttributeMapperFactory do
           connection: connection
         )
 
-        result = factory.build_with_defaults { { "firstName" => "first_name" } }
+        result = factory.build_with_defaults do |mappings|
+          mappings.create!(
+            integration_field_name: "firstName",
+            namely_field_name: "first_name",
+          )
+        end
 
         expect(connection.reload.attribute_mapper_id).to eq(result.id)
         expect(mapped_fields_for(result)).to eq([%w(firstName first_name)])

--- a/spec/models/field_mapping_spec.rb
+++ b/spec/models/field_mapping_spec.rb
@@ -33,6 +33,38 @@ describe FieldMapping do
     end
   end
 
+  describe ".map!" do
+    context "for an existing field" do
+      it "leaves the existing field" do
+        attribute_mapper = create(:attribute_mapper)
+        create(
+          :field_mapping,
+          attribute_mapper: attribute_mapper,
+          integration_field_name: "integration",
+          namely_field_name: "mapped"
+        )
+
+        attribute_mapper.field_mappings.map!("integration")
+
+        result = FieldMapping.last
+        expect(result.integration_field_name).to eq("integration")
+        expect(result.namely_field_name).to eq("mapped")
+      end
+    end
+
+    context "for a new field" do
+      it "creates the field" do
+        attribute_mapper = create(:attribute_mapper)
+
+        attribute_mapper.field_mappings.map!("integration", to: "namely")
+
+        result = FieldMapping.last
+        expect(result.integration_field_name).to eq("integration")
+        expect(result.namely_field_name).to eq("namely")
+      end
+    end
+  end
+
   def integration_key(field_name:)
     FieldMapping.new(integration_field_name: field_name).integration_key
   end


### PR DESCRIPTION
We need to add more than just to/from, because we need to store
attribute metadata from integration responses.

This commit expands the API from a hash to method calls so that several
fields can be provided.