### PR TITLE
Always normalize nested fields like job title

### DIFF
--- a/app/models/net_suite/normalizer.rb
+++ b/app/models/net_suite/normalizer.rb
@@ -19,17 +19,11 @@ class NetSuite::Normalizer
     attribute_mapper.export(profile).tap do |exported_profile|
       exported_profile["gender"] = map_gender(exported_profile["gender"])
       exported_profile["subsidiary"] = set_subsidiary_id
-      exported_profile["title"] = format_job_title(exported_profile["title"])
       convert_custom_fields(exported_profile)
     end
   end
 
   private
-
-  def format_job_title(value)
-    value = Hash(value)
-    value.fetch("title") { "" }
-  end
 
   def map_gender(value)
     GENDER_MAP[value]

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,5 +1,4 @@
 class Profile
-  delegate :[], to: :namely_profile
   delegate :update, to: :namely_profile
 
   def initialize(namely_profile)
@@ -10,7 +9,19 @@ class Profile
     "#{namely_profile[:first_name]} #{namely_profile[:last_name]}"
   end
 
+  def [](key)
+    flatten_hash namely_profile[key]
+  end
+
   private
+
+  def flatten_hash(value)
+    if value.respond_to?(:to_hash)
+      value.to_hash["title"] || value.to_hash["name"]
+    else
+      value
+    end
+  end
 
   attr_reader :namely_profile
 end

--- a/spec/models/net_suite/normalizer_spec.rb
+++ b/spec/models/net_suite/normalizer_spec.rb
@@ -87,29 +87,6 @@ describe NetSuite::Normalizer do
       end
     end
 
-    context "job title" do
-      it "extracts the job_title name" do
-        title = "Robot"
-        job_title = stubbed_job_title(title)
-        profile_data = stubbed_profile_data.merge(job_title)
-
-        export_attributes = export(profile_data)
-
-        expect(export_attributes["title"]).to eq(title)
-      end
-
-      context "nil value" do
-        it "sets an empty string" do
-          job_title = stubbed_job_title("")
-          profile_data = stubbed_profile_data.merge(job_title)
-
-          export_attributes = export(profile_data)
-
-          expect(export_attributes["title"]).to eq("")
-        end
-      end
-    end
-
     context "subsidiary_id" do
       it "provides a subsidiary_id from the configuration" do
         export_attributes = export
@@ -186,15 +163,6 @@ describe NetSuite::Normalizer do
       "gender" => "Female",
       "home_phone" => "212-555-1212",
       "last_name" => "Last"
-    }.merge(stubbed_job_title("Robot"))
-  end
-
-  def stubbed_job_title(title)
-    {
-      "job_title" => {
-        "id" => "1234",
-        "title" => title
-      }
     }
   end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -3,8 +3,34 @@ require "rails_helper"
 describe Profile do
   describe "delegations" do
     subject { Profile.new(stub_profile_data) }
-    it { should delegate_method(:[]).to(:namely_profile) }
     it { should delegate_method(:update).to(:namely_profile) }
+  end
+
+  describe "#[]" do
+    context "with a hash" do
+      it "finds the value of the first, non-id key" do
+        profile = Profile.new(
+          "job_title" => {
+            "id" => "x",
+            "title" => "expected",
+          }
+        )
+
+        result = profile["job_title"]
+
+        expect(result).to eq("expected")
+      end
+    end
+
+    context "with other types" do
+      it "returns the original value" do
+        profile = Profile.new("name" => "expected")
+
+        result = profile["name"]
+
+        expect(result).to eq("expected")
+      end
+    end
   end
 
   describe "#name" do


### PR DESCRIPTION
Because:

* Users can map any Namely field to any NetSuite field
* Fields like job title require converting to send a string
* Mapping job title to another field causes a crash

This commit:

Removes the assumption that job title in Namely is always
mapped to title in NetSuite

https://trello.com/c/NmSrVVJi