### PR TITLE
Remove rack-timeout from development, test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "namely", "~> 0.2.1"
 gem "neat", "~> 1.5.1"
 gem "normalize-rails", "~> 3.0.0"
 gem "pg"
-gem "rack-timeout"
 gem "recipient_interceptor"
 gem "rest-client"
 gem "sass-rails", "~> 4.0.3"
@@ -53,4 +52,5 @@ end
 group :staging, :production do
   gem 'rails_12factor'
   gem 'honeybadger'
+  gem "rack-timeout"
 end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,3 @@
-Rack::Timeout.timeout = (ENV["TIMEOUT_IN_SECONDS"] || 20).to_i
+if defined?(Rack::Timeout)
+  Rack::Timeout.timeout = (ENV["TIMEOUT_IN_SECONDS"] || 180).to_i
+end

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,1 +1,0 @@
-Rack::Timeout.timeout = 180


### PR DESCRIPTION
Because:

* Integration tests are randomly hanging
* rack-test interacts strangely with threads

This commit:

* Removes rack-timeout from development and test

https://trello.com/c/sMfXD1IQ