### PR TITLE
Generate better instance names on Cloud Elements

### DIFF
--- a/app/models/net_suite/authentication.rb
+++ b/app/models/net_suite/authentication.rb
@@ -25,7 +25,7 @@ module NetSuite
     private
 
     def create_instance
-      result = @client.create_instance(attributes)
+      result = @client.create_instance(self)
       if result.success?
         @connection.update!(
           instance_id: result[:id],

--- a/app/models/net_suite/client.rb
+++ b/app/models/net_suite/client.rb
@@ -33,21 +33,11 @@ module NetSuite
       )
     end
 
-    def create_instance(params)
+    def create_instance(authentication)
       submit_json(
         :post,
         INSTANCES,
-        "configuration" => {
-          "user.username" => params[:email],
-          "user.password" => params[:password],
-          "netsuite.accountId" => params[:account_id],
-          "netsuite.sandbox" => false
-        },
-        "element" => {
-          "key" => "netsuiteerp"
-        },
-        "tags" => [],
-        "name" => "#{params[:account_id]}_netsuite"
+        Instance.new(authentication).to_h
       )
     end
 

--- a/app/models/net_suite/instance.rb
+++ b/app/models/net_suite/instance.rb
@@ -1,0 +1,36 @@
+module NetSuite
+  class Instance
+    def initialize(authentication)
+      @authentication = authentication
+    end
+
+    def to_h
+      {
+        "configuration" => {
+          "user.username" => authentication.email,
+          "user.password" => authentication.password,
+          "netsuite.accountId" => authentication.account_id,
+          "netsuite.sandbox" => false
+        },
+        "element" => {
+          "key" => "netsuiteerp"
+        },
+        "tags" => [],
+        "name" => name
+      }
+    end
+
+    private
+
+    attr_reader :authentication
+
+    def name
+      [
+        Rails.env,
+        Time.current.to_s(:number),
+        authentication.account_id,
+        "netsuite"
+      ].join("_")
+    end
+  end
+end

--- a/spec/models/net_suite/authentication_spec.rb
+++ b/spec/models/net_suite/authentication_spec.rb
@@ -20,7 +20,7 @@ describe NetSuite::Authentication do
           authorization: "def"
         )
         expect(client).
-          to have_received(:create_instance).with(form_attributes)
+          to have_received(:create_instance).with(form)
       end
     end
 

--- a/spec/models/net_suite/instance_spec.rb
+++ b/spec/models/net_suite/instance_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe NetSuite::Instance do
+  describe "#to_h" do
+    it "returns a hash usable for instance creation" do
+      Timecop.freeze do
+        rails_env = "environment"
+        allow(Rails).to receive(:env).and_return(rails_env)
+        authentication = double(
+          NetSuite::Authentication,
+          email: "test@example.com",
+          password: "sekret",
+          account_id: "42"
+        )
+
+        instance_hash = NetSuite::Instance.new(authentication).to_h
+        config = instance_hash["configuration"]
+        element = instance_hash["element"]
+
+        expect(config["user.username"]).to eq authentication.email
+        expect(config["user.password"]).to eq authentication.password
+        expect(config["netsuite.accountId"]).to eq authentication.account_id
+        expect(config["netsuite.sandbox"]).to eq false
+        expect(element["key"]).to eq "netsuiteerp"
+        expect(instance_hash["tags"]).to eq []
+        expect(instance_hash["name"]).to eq(
+          "#{rails_env}_" \
+          "#{Time.current.to_s(:number)}_" \
+          "#{authentication.account_id}_" \
+          "netsuite"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, we had many conflicting instance names because they were
keyed only on the account id. This was confusing in development, but
potentially dangerous as we rolled out to other environments where the
instance names would conflict yet again.

This change adds both the Rails environment and a timestamp to the name
to help make finding the correct cloud elements instance easier.