### PR TITLE
Add task for clearing local field mappings

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,0 +1,8 @@
+if Rails.env.development?
+  namespace :dev do
+    desc "Clear all local field mappings for debugging"
+    task reset_field_mappings: :environment do
+      AttributeMapper.destroy_all
+    end
+  end
+end


### PR DESCRIPTION
We need to do this a lot when debugging locally so that we can test out uncached UI interactions.