### PR TITLE
Allow editing of configuration and field mappings

### DIFF
--- a/app/models/greenhouse/connection.rb
+++ b/app/models/greenhouse/connection.rb
@@ -20,6 +20,10 @@ module Greenhouse
       false
     end
 
+    def configurable?
+      false
+    end
+
     def required_namely_field
       "greenhouse_id"
     end

--- a/app/models/icims/connection.rb
+++ b/app/models/icims/connection.rb
@@ -28,6 +28,10 @@ module Icims
       false
     end
 
+    def configurable?
+      false
+    end
+
     def required_namely_field
       Normalizer.new.namely_identifier_field.to_s
     end

--- a/app/models/jobvite/connection.rb
+++ b/app/models/jobvite/connection.rb
@@ -25,6 +25,10 @@ module Jobvite
       true
     end
 
+    def configurable?
+      false
+    end
+
     def attribute_mapper
       AttributeMapperFactory.new(attribute_mapper: super, connection: self).
         build_with_defaults do |mappings|

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -26,6 +26,10 @@ class NetSuite::Connection < ActiveRecord::Base
     true
   end
 
+  def configurable?
+    true
+  end
+
   def attribute_mapper
     AttributeMapperFactory.new(attribute_mapper: super, connection: self).
       build_with_defaults { |mappings| map_defaults(mappings) }

--- a/app/views/dashboards/_connected_connection.html.erb
+++ b/app/views/dashboards/_connected_connection.html.erb
@@ -24,5 +24,5 @@
   ) %>
 <% end %>
 
-<%= render "edit_button", integration_id: connection.integration_id %>
-<%= render "disconnect_button", integration_id: connection.integration_id %>
+<%= render "edit_actions", connection: connection %>
+<%= render "disconnect_button", connection: connection %>

--- a/app/views/dashboards/_disconnect_button.html.erb
+++ b/app/views/dashboards/_disconnect_button.html.erb
@@ -1,4 +1,9 @@
-<%= button_to integration_connection_path(integration_id), class: "-n-btn -n-btn-sm -n-btn-danger -n-btn-link", method: :delete, rel: "nofollow" do %>
+<%= button_to(
+  integration_connection_path(connection.integration_id),
+  class: "-n-btn -n-btn-sm -n-btn-danger -n-btn-link",
+  method: :delete,
+  rel: "nofollow"
+) do %>
   <%= fa_icon "times" %>
   <%= t("dashboards.show.disconnect") %>
 <% end %>

--- a/app/views/dashboards/_edit_actions.html.erb
+++ b/app/views/dashboards/_edit_actions.html.erb
@@ -1,0 +1,14 @@
+<%= link_to t("dashboards.show.edit_credentials"),
+  edit_integration_authentication_path(connection.integration_id),
+  class: "-n-btn -n-btn-sm -n-btn-link" %>
+
+<% if connection.configurable? %>
+  <%= link_to t("dashboards.show.edit_configuration"),
+    edit_integration_connection_path(connection.integration_id),
+    class: "-n-btn -n-btn-sm -n-btn-link" %>
+<% end %>
+
+<% if connection.attribute_mapper? %>
+  <%= link_to t("dashboards.show.edit_mappings"),
+    edit_integration_mapping_path(connection.integration_id) %>
+<% end %>

--- a/app/views/dashboards/_edit_button.html.erb
+++ b/app/views/dashboards/_edit_button.html.erb
@@ -1,3 +1,0 @@
-<%= link_to edit_integration_authentication_path(integration_id), class: "-n-btn -n-btn-sm -n-btn-link" do %>
-  <%= t("dashboards.show.edit") %>
-<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,7 +7,9 @@ en:
     show:
       connect: "Connect"
       disconnect: "Disconnect"
-      edit: "Edit"
+      edit_configuration: Edit Configuration
+      edit_credentials: Edit Credentials
+      edit_mappings: Edit Field Mappings
       export_now: "Export now"
       import_now: "Import now"
       sign_out: "Sign out"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -48,6 +48,10 @@ FactoryGirl.define do
       api_key nil
       secret nil
     end
+
+    trait :with_namely_field do
+      found_namely_field true
+    end
   end
 
   factory :greenhouse_connection, class: "Greenhouse::Connection" do

--- a/spec/features/user_connects_net_suite_account_spec.rb
+++ b/spec/features/user_connects_net_suite_account_spec.rb
@@ -5,7 +5,7 @@ feature "user connects NetSuite account" do
     stub_namely_fields("fields_with_net_suite")
     stub_net_suite_fields
     stub_create_instance(status: 200, body: { id: "123", token: "abcxyz" })
-    stub_lookup_subsidiaries(
+    stub_net_suite_subsidiaries(
       status: 200,
       body: [
         { "internalId": "1", "name": "First" },
@@ -41,7 +41,7 @@ feature "user connects NetSuite account" do
     stub_namely_fields("fields_with_net_suite")
     stub_net_suite_fields
     stub_create_instance(status: 200, body: { id: "123", token: "abcxyz" })
-    stub_lookup_subsidiaries(
+    stub_net_suite_subsidiaries(
       status: 200,
       body: [{ "internalId": "1", "name": "First" }]
     )
@@ -52,7 +52,7 @@ feature "user connects NetSuite account" do
     select_net_suite_subsidiary("First")
     save_attribute_mappings
 
-    net_suite.click_link t("dashboards.show.edit")
+    net_suite.click_link t("dashboards.show.edit_credentials")
     submit_net_suite_account_form
     expect(net_suite).
       to have_text_from("net_suite_connections.description.connected_html")
@@ -83,23 +83,6 @@ feature "user connects NetSuite account" do
     stub_request(
       :post,
       "https://api.cloud-elements.com/elements/api-v2/instances"
-    ).to_return(status: status, body: JSON.dump(body))
-  end
-
-  def stub_net_suite_fields
-    net_suite_employee =
-      File.read("spec/fixtures/api_responses/net_suite_employee.json")
-    stub_request(
-      :get,
-      %r{.*/elements/api-v2/hubs/erp/employees\?.*}
-    ).to_return(status: 200, body: net_suite_employee)
-  end
-
-  def stub_lookup_subsidiaries(status:, body:)
-    stub_request(
-      :get,
-      "https://api.cloud-elements.com/" \
-        "elements/api-v2/hubs/erp/lookups/subsidiary"
     ).to_return(status: status, body: JSON.dump(body))
   end
 

--- a/spec/features/user_edits_connection_configuration_spec.rb
+++ b/spec/features/user_edits_connection_configuration_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+feature "User edits connection configuration" do
+  scenario "successfully" do
+    original_subsidiary = { internalId: "1", name: "Original" }
+    new_subsidiary = { internalId: "2", name: "New" }
+    user = create(:user)
+    connection = create(
+      :net_suite_connection,
+      :connected,
+      :with_namely_field,
+      installation: user.installation,
+      subsidiary_id: original_subsidiary[:internalId]
+    )
+    stub_mapping_requests
+    stub_net_suite_subsidiaries(
+      status: 200,
+      body: [original_subsidiary, new_subsidiary]
+    )
+
+    visit dashboard_path(as: user)
+    click_net_suite_configuration_link
+    subsidiary_id_field.select(new_subsidiary[:name])
+    click_button t("dashboards.show.connect")
+    visit edit_integration_connection_path(connection.integration_id)
+
+    expect(subsidiary_id_field.value).
+      to eq new_subsidiary[:internalId]
+  end
+
+  def click_net_suite_configuration_link
+    within(".net-suite-account") do
+      click_link t("dashboards.show.edit_configuration")
+    end
+  end
+
+  def subsidiary_id_field
+    find("#net_suite_connection_subsidiary_id")
+  end
+
+  def stub_mapping_requests
+    stub_net_suite_fields
+    stub_namely_fields("fields_with_net_suite")
+  end
+end

--- a/spec/features/user_edits_existing_field_mappings_spec.rb
+++ b/spec/features/user_edits_existing_field_mappings_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+feature "User edits existing field mappings" do
+  scenario "successfully" do
+    personal_email = { text: "Personal email", value: "personal_email" }
+    stub_namely_fields("fields_with_jobvite")
+    user = create(:user)
+    create(
+      :jobvite_connection,
+      :connected,
+      :with_namely_field,
+      installation: user.installation
+    )
+
+    visit dashboard_path(as: user)
+    click_jobvite_mappings_link
+    first_mappable_field.select(personal_email[:text])
+    click_button t("attribute_mappings.edit.save")
+    click_jobvite_mappings_link
+
+    expect(first_mappable_field.value).to eq(personal_email[:value])
+  end
+
+  def click_jobvite_mappings_link
+    within(".jobvite-account") do
+      click_link t("dashboards.show.edit_mappings")
+    end
+  end
+
+  def first_mappable_field
+    find("select", match: :first)
+  end
+end

--- a/spec/support/features/net_suite_requests_helper.rb
+++ b/spec/support/features/net_suite_requests_helper.rb
@@ -1,0 +1,18 @@
+module Features
+  def stub_net_suite_subsidiaries(status:, body:)
+    stub_request(
+      :get,
+      "https://api.cloud-elements.com/" \
+        "elements/api-v2/hubs/erp/lookups/subsidiary"
+    ).to_return(status: status, body: JSON.dump(body))
+  end
+
+  def stub_net_suite_fields
+    net_suite_employee =
+      File.read("spec/fixtures/api_responses/net_suite_employee.json")
+    stub_request(
+      :get,
+      %r{.*/elements/api-v2/hubs/erp/employees\?.*}
+    ).to_return(status: 200, body: net_suite_employee)
+  end
+end


### PR DESCRIPTION
Previous to this change, users with existing connections could only
edit authentication information. They were unable to edit existing
mappings or to change any additional configuration information
(i.e. NetSuite subsidiary).

This change adds distinct edit links for configuration and mapping
where applicable.