### PR TITLE
Users can select mappings for Greenhouse accounts

### DIFF
--- a/app/models/greenhouse/connection.rb
+++ b/app/models/greenhouse/connection.rb
@@ -1,5 +1,6 @@
 module Greenhouse
   class Connection < ActiveRecord::Base
+    belongs_to :attribute_mapper, dependent: :destroy
     belongs_to :installation
     validates :secret_key, uniqueness: true
     before_create :set_secret_key
@@ -17,7 +18,23 @@ module Greenhouse
     end
 
     def attribute_mapper?
-      false
+      true
+    end
+
+    def attribute_mapper
+      AttributeMapperFactory.new(attribute_mapper: super, connection: self).
+        build_with_defaults do |mappings|
+          mappings.map! "first_name", to: "first_name", name: "First name"
+          mappings.map! "middle_name", to: "middle_name", name: "Middle name"
+          mappings.map! "last_name", to: "last_name", name: "Last name"
+          mappings.map! "work_email", to: "email", name: "Work email"
+          mappings.map!(
+            "personal_email",
+            to: "personal_email",
+            name: "Personal email"
+          )
+          mappings.map! "starts_at", to: "start_date", name: "Starts at"
+        end
     end
 
     def configurable?

--- a/app/services/greenhouse/candidate_import_assistant.rb
+++ b/app/services/greenhouse/candidate_import_assistant.rb
@@ -15,7 +15,8 @@ module Greenhouse
 
     def normalizer
       Normalizer.new(
-        context.installation.namely_connection.fields.all
+        attribute_mapper: connection.attribute_mapper,
+        namely_fields: context.installation.namely_connection.fields.all
       )
     end
 

--- a/db/migrate/20150825134808_add_attribute_mapper_id_to_greenhouse_connections.rb
+++ b/db/migrate/20150825134808_add_attribute_mapper_id_to_greenhouse_connections.rb
@@ -1,0 +1,5 @@
+class AddAttributeMapperIdToGreenhouseConnections < ActiveRecord::Migration
+  def change
+    add_column :greenhouse_connections, :attribute_mapper_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150818175042) do
+ActiveRecord::Schema.define(version: 20150825134808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,12 +58,13 @@ ActiveRecord::Schema.define(version: 20150818175042) do
   add_index "field_mappings", ["attribute_mapper_id"], name: "index_field_mappings_on_attribute_mapper_id", using: :btree
 
   create_table "greenhouse_connections", force: true do |t|
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.string   "secret_key"
     t.string   "name"
-    t.boolean  "found_namely_field", default: false, null: false
-    t.integer  "installation_id",                    null: false
+    t.boolean  "found_namely_field",  default: false, null: false
+    t.integer  "installation_id",                     null: false
+    t.integer  "attribute_mapper_id"
   end
 
   add_index "greenhouse_connections", ["installation_id"], name: "index_greenhouse_connections_on_installation_id", using: :btree

--- a/spec/features/user_connects_greenhouse_account_spec.rb
+++ b/spec/features/user_connects_greenhouse_account_spec.rb
@@ -16,6 +16,8 @@ feature "User connects Greenhouse account" do
     fill_in field("greenhouse_authentication.name"), with: "name"
     click_button button("greenhouse_connection.update")
 
+    click_on t("attribute_mappings.edit.save")
+
     within(".greenhouse-account") do
       expect(page).to have_no_link t("dashboards.show.connect")
       expect(page).to have_content(greenhouse_candidate_imports_url("greenhouse_key"))

--- a/spec/models/greenhouse/connection_spec.rb
+++ b/spec/models/greenhouse/connection_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Greenhouse::Connection, :type => :model do
   describe "associations" do
     subject { build(:greenhouse_connection) }
+    it { is_expected.to belong_to(:attribute_mapper).dependent(:destroy) }
     it { is_expected.to belong_to(:installation) }
     it { is_expected.to validate_uniqueness_of(:secret_key) }
   end
@@ -25,6 +26,35 @@ RSpec.describe Greenhouse::Connection, :type => :model do
     it 'generates a secret key' do
       greenhouse_connection = create :greenhouse_connection, :connected
       expect(greenhouse_connection.secret_key).to_not be_nil
+    end
+  end
+
+  describe "#attribute_mapper" do
+    it "builds and saves an attribute mapper" do
+      installation = build(:installation)
+      connection = Greenhouse::Connection.new(
+        installation: installation,
+        name: "example"
+      )
+
+      connection.save!
+
+      expect(connection.attribute_mapper).to be_an_instance_of(AttributeMapper)
+      expect(connection.attribute_mapper).to be_persisted
+      expect(mapped_fields(connection.attribute_mapper)).to match_array([
+        %w(first_name first_name),
+        %w(middle_name middle_name),
+        %w(last_name last_name),
+        %w(work_email email),
+        %w(personal_email personal_email),
+        %w(starts_at start_date),
+      ])
+    end
+  end
+
+  def mapped_fields(attribute_mapper)
+    attribute_mapper.field_mappings.map do |field_mapping|
+      [field_mapping.integration_field_id, field_mapping.namely_field_name]
     end
   end
 end

--- a/spec/services/greenhouse/candidate_import_assistant_spec.rb
+++ b/spec/services/greenhouse/candidate_import_assistant_spec.rb
@@ -44,7 +44,10 @@ describe Greenhouse::CandidateImportAssistant do
   def candidate_importer_double
     double(
       CandidateImporter,
-      connection: double(:connection),
+      connection: double(
+        :connection,
+        attribute_mapper: double(:attribute_mapper)
+      ),
       params: {},
       installation: double(
         :installation,


### PR DESCRIPTION
Because:

* Greenhouse contains fields that Namely doesn't
* Users can create custom fields in Namely for those fields

This commit:

* Adds attribute mapping for Greenhouse connections
* Maintains hard mappings for address and salary, which we can't map yet

https://trello.com/c/kYjN3NrG