### PR TITLE
Map namely user status to NetSuite inactive flag

### DIFF
--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -91,6 +91,7 @@ class NetSuite::Connection < ActiveRecord::Base
     mappings.map! "email", to: "email", name: "Email"
     mappings.map! "firstName", to: "first_name", name: "First name"
     mappings.map! "gender", to: "gender", name: "Gender"
+    mappings.map! "isInactive", to: "user_status", name: "Inactive"
     mappings.map! "lastName", to: "last_name", name: "Last name"
     mappings.map! "middleName", to: "middle_name", name: "Middle name"
     mappings.map! "mobilePhone", to: "mobile_phone", name: "Mobile phone"

--- a/app/models/net_suite/normalizer.rb
+++ b/app/models/net_suite/normalizer.rb
@@ -18,6 +18,9 @@ class NetSuite::Normalizer
   def export(profile)
     attribute_mapper.export(profile).tap do |exported_profile|
       exported_profile["gender"] = map_gender(exported_profile["gender"])
+      exported_profile["isInactive"] = map_user_status(
+        exported_profile["isInactive"]
+      )
       exported_profile["subsidiary"] = set_subsidiary_id
       convert_custom_fields(exported_profile)
     end
@@ -27,6 +30,10 @@ class NetSuite::Normalizer
 
   def map_gender(value)
     GENDER_MAP[value]
+  end
+
+  def map_user_status(value)
+    value == "inactive"
   end
 
   def set_subsidiary_id

--- a/spec/models/net_suite/connection_spec.rb
+++ b/spec/models/net_suite/connection_spec.rb
@@ -84,6 +84,7 @@ describe NetSuite::Connection do
         %w(email email),
         %w(firstName first_name),
         %w(gender gender),
+        %w(isInactive user_status),
         %w(lastName last_name),
         %w(middleName middle_name),
         %w(mobilePhone mobile_phone),

--- a/spec/models/net_suite/normalizer_spec.rb
+++ b/spec/models/net_suite/normalizer_spec.rb
@@ -17,6 +17,7 @@ describe NetSuite::Normalizer do
         email
         firstName
         gender
+        isInactive
         lastName
         phone
       ))
@@ -84,6 +85,24 @@ describe NetSuite::Normalizer do
         export_attributes = export(profile_data)
 
         expect(export_attributes["gender"]).to eq("_omitted")
+      end
+    end
+
+    context "isInactive" do
+      it "maps a user status of 'inactive' to true" do
+        profile_data = stubbed_profile_data.merge("user_status" => "inactive")
+
+        export_attributes = export(profile_data)
+
+        expect(export_attributes["isInactive"]).to be true
+      end
+
+      it "maps user_status of 'active' values to false" do
+        profile_data = stubbed_profile_data.merge("user_status" => "active")
+
+        export_attributes = export(profile_data)
+
+        expect(export_attributes["isInactive"]).to be false
       end
     end
 


### PR DESCRIPTION
This is a field that users are likely to want synchronized between the
two systems, so we've added a default mapping for it. The mapping must
be normalized because the types differ between the systems.