### PR TITLE
Allow NetSuite to operate without a subsidiary

### DIFF
--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -27,7 +27,7 @@ class NetSuite::Connection < ActiveRecord::Base
   end
 
   def configurable?
-    true
+    !subsidiary_optional?
   end
 
   def attribute_mapper
@@ -36,7 +36,7 @@ class NetSuite::Connection < ActiveRecord::Base
   end
 
   def ready?
-    subsidiary_id.present?
+    subsidiary_id.present? || subsidiary_optional?
   end
 
   def required_namely_field
@@ -62,6 +62,14 @@ class NetSuite::Connection < ActiveRecord::Base
   end
 
   private
+
+  def subsidiary_optional?
+    if subsidiary_required.nil?
+      update!(subsidiary_required: subsidiaries.present?)
+    end
+
+    !subsidiary_required?
+  end
 
   def normalizer
     @normalizer ||= NetSuite::Normalizer.new(

--- a/db/migrate/20150827155439_add_require_subsidiary_to_net_suite_connections.rb
+++ b/db/migrate/20150827155439_add_require_subsidiary_to_net_suite_connections.rb
@@ -1,0 +1,5 @@
+class AddRequireSubsidiaryToNetSuiteConnections < ActiveRecord::Migration
+  def change
+    add_column :net_suite_connections, :subsidiary_required, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150825134808) do
+ActiveRecord::Schema.define(version: 20150827155439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 20150825134808) do
     t.string   "subsidiary_id"
     t.integer  "attribute_mapper_id"
     t.integer  "installation_id",                     null: false
+    t.boolean  "subsidiary_required"
   end
 
   add_index "net_suite_connections", ["attribute_mapper_id"], name: "index_net_suite_connections_on_attribute_mapper_id", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
     trait :connected do
       instance_id "123xy"
       authorization "abc12z"
+      subsidiary_required true
     end
 
     trait :with_namely_field do


### PR DESCRIPTION
Because:

* Users can setup NetSuite without subsidiaries

This commit:

* Checks to see if NetSuite is configured with subsidiaries
* Skips subsidiary configuration when none are present

Side effects:

* Adds a cache column to prevent repeated NetSuite requests

https://trello.com/c/43U5qp9V