### PR TITLE
Map Namely departure date to NetSuite release date

### DIFF
--- a/app/models/fields/date_value.rb
+++ b/app/models/fields/date_value.rb
@@ -16,7 +16,11 @@ module Fields
     end
 
     def to_date
-      DateTime.strptime(@value, DATE_FORMAT).to_date
+      if @value.present?
+        DateTime.strptime(@value, DATE_FORMAT).to_date
+      end
+    rescue ArgumentError
+      nil
     end
 
     def to_address

--- a/app/models/fields/null_value.rb
+++ b/app/models/fields/null_value.rb
@@ -1,0 +1,19 @@
+module Fields
+  class NullValue
+    def to_raw
+      nil
+    end
+
+    def to_s
+      nil
+    end
+
+    def to_date
+      nil
+    end
+
+    def to_address
+      nil
+    end
+  end
+end

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -112,5 +112,11 @@ class NetSuite::Connection < ActiveRecord::Base
     mappings.map! "officePhone", to: "office_phone", name: "Office phone"
     mappings.map! "phone", to: "home_phone", name: "Phone"
     mappings.map! "title", to: "job_title", name: "Title"
+
+    mappings.map!(
+      "releaseDate",
+      to: "departure_date",
+      name: "Release Date"
+    )
   end
 end

--- a/app/models/net_suite/normalizer.rb
+++ b/app/models/net_suite/normalizer.rb
@@ -24,10 +24,12 @@ class NetSuite::Normalizer
     end
 
     def to_hash
-      mapped_attributes.
-        merge(address_attributes).
-        merge(string_attributes).
-        merge(custom_fields_attributes)
+      with_null_field_list(
+        mapped_attributes.
+          merge(address_attributes).
+          merge(string_attributes).
+          merge(custom_fields_attributes)
+      )
     end
 
     private
@@ -147,6 +149,14 @@ class NetSuite::Normalizer
       if @attributes["address"]
         @attributes["address"].to_address
       end
+    end
+
+    def with_null_field_list(fields)
+      fields.tap do |mapped_fields|
+        mapped_fields["nullFieldList"] = mapped_fields.select do |_, value|
+          value.nil?
+        end.keys
+      end.compact
     end
   end
 

--- a/app/models/net_suite/normalizer.rb
+++ b/app/models/net_suite/normalizer.rb
@@ -37,6 +37,7 @@ class NetSuite::Normalizer
         "gender" => gender,
         "isInactive" => user_status,
         "subsidiary" => subsidiary,
+        "releaseDate" => release_date,
       }
     end
 
@@ -63,6 +64,14 @@ class NetSuite::Normalizer
 
     def user_status
       @attributes["isInactive"].to_s == "inactive"
+    end
+
+    def release_date
+      date = @attributes.fetch("releaseDate", Fields::NullValue.new).to_date
+
+      if date.present?
+        date.to_datetime.to_i * 1.second.in_milliseconds
+      end
     end
 
     def subsidiary

--- a/spec/models/fields/date_value_spec.rb
+++ b/spec/models/fields/date_value_spec.rb
@@ -18,6 +18,14 @@ describe Fields::DateValue do
       expect(Fields::DateValue.new("08/26/1986").to_date).
         to eq(Date.new(1986, 8, 26))
     end
+
+    it "is nil for empty string values" do
+      expect(Fields::DateValue.new("").to_date).to be nil
+    end
+
+    it "is nil for things that don't parse to a date" do
+      expect(Fields::DateValue.new("foo").to_date).to be nil
+    end
   end
 
   describe "#to_address" do

--- a/spec/models/net_suite/connection_spec.rb
+++ b/spec/models/net_suite/connection_spec.rb
@@ -161,6 +161,7 @@ describe NetSuite::Connection do
         %w(mobilePhone mobile_phone),
         %w(officePhone office_phone),
         %w(phone home_phone),
+        %w(releaseDate departure_date),
         %w(title job_title),
         %w(address home),
         ["initials", nil],

--- a/spec/models/net_suite/normalizer_spec.rb
+++ b/spec/models/net_suite/normalizer_spec.rb
@@ -236,7 +236,7 @@ describe NetSuite::Normalizer do
     context "null scalar fields" do
       it "moves keys with null scalar values to the nullFieldList" do
         profile_data = stubbed_profile_data.merge(
-          "departure_date" => nil
+          "departure_date" => Fields::DateValue.new(nil)
         )
 
         export_attributes = export(profile_data)


### PR DESCRIPTION
These are the names for the termination date concept in each system.
CloudElements/NetSuite require milliseconds since epoch, so we need to
normalize for that.

Issues to follow up on:

* Can't clear release date in NetSuite once it is set. Neither setting
  to empty string nor nil works. It's unclear if this is a NetSuite or
  CloudElements issue.
* Setting departure date as, for example, 09/05/2015 in Namely causes it
  to sync to NetSuite as milliseconds since the epoch (UTC) at midnight
  of that day. When displayed in NetSuite it seems some time zone
  conversion is done, causing the date to be displayed as 09/04/2015.
  Not sure if there's a sensible thing to do here.