### PR TITLE
Refactor type conversion for profile values

### DIFF
--- a/app/models/fields/collection.rb
+++ b/app/models/fields/collection.rb
@@ -1,0 +1,40 @@
+module Fields
+  # Wraps values from Namely profile fields in an object able to convert to
+  # useful formats.
+  #
+  # See value classes like {StringValue} for examples.
+  class Collection
+    def initialize(namely_connection)
+      @namely_connection = namely_connection
+    end
+
+    def export(field_name, from:)
+      value = from[field_name]
+      field = find_field(field_name)
+      if value && field
+        factory_for(field.type).new(value)
+      end
+    end
+
+    private
+
+    def find_field(field_name)
+      fields.detect { |field| field.name == field_name }
+    end
+
+    def factory_for(type)
+      case type
+      when "referencehistory"
+        RecordValue
+      when "date"
+        DateValue
+      else
+        StringValue
+      end
+    end
+
+    def fields
+      @namely_connection.fields.all
+    end
+  end
+end

--- a/app/models/fields/date_value.rb
+++ b/app/models/fields/date_value.rb
@@ -1,0 +1,24 @@
+module Fields
+  # Converts date values from Namely.
+  class DateValue
+    DATE_FORMAT = "%m/%d/%Y"
+
+    def initialize(value)
+      @value = value
+    end
+
+    def to_raw
+      @value
+    end
+
+    def to_s
+      @value.to_s
+    end
+
+    def to_date
+      DateTime.strptime(@value, DATE_FORMAT).to_date
+    end
+
+    private_constant :DATE_FORMAT
+  end
+end

--- a/app/models/fields/record_value.rb
+++ b/app/models/fields/record_value.rb
@@ -1,0 +1,26 @@
+module Fields
+  # Converts record values like job titles from Namely into useful formats.
+  class RecordValue
+    def initialize(value)
+      @value = value
+    end
+
+    def to_raw
+      @value
+    end
+
+    def to_s
+      @value[non_id_key]
+    end
+
+    def to_date
+      nil
+    end
+
+    private
+
+    def non_id_key
+      @value.except("id").keys.first
+    end
+  end
+end

--- a/app/models/fields/string_value.rb
+++ b/app/models/fields/string_value.rb
@@ -1,0 +1,20 @@
+module Fields
+  # Converts string values from Namely into other formats.
+  class StringValue
+    def initialize(value)
+      @value = value
+    end
+
+    def to_raw
+      @value
+    end
+
+    def to_s
+      @value.to_s
+    end
+
+    def to_date
+      nil
+    end
+  end
+end

--- a/app/models/net_suite/export.rb
+++ b/app/models/net_suite/export.rb
@@ -48,7 +48,7 @@ module NetSuite
       end
 
       def update
-        response = @net_suite.update_employee(id, attributes)
+        response = @net_suite.update_employee(id.to_s, attributes)
         Result.new(response, true, @profile)
       end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,8 +1,9 @@
 class Profile
   delegate :update, to: :namely_profile
 
-  def initialize(namely_profile)
+  def initialize(namely_profile, fields:)
     @namely_profile = namely_profile
+    @fields = fields
   end
 
   def name
@@ -10,18 +11,10 @@ class Profile
   end
 
   def [](key)
-    flatten_hash namely_profile[key]
+    @fields.export(key, from: @namely_profile)
   end
 
   private
-
-  def flatten_hash(value)
-    if value.respond_to?(:to_hash)
-      value.to_hash["title"] || value.to_hash["name"]
-    else
-      value
-    end
-  end
 
   attr_reader :namely_profile
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,9 @@ class User < ActiveRecord::Base
   end
 
   def namely_profiles
-    namely_connection.profiles.all.map { |profile| Profile.new(profile) }
+    namely_connection.profiles.all.map do |profile|
+      Profile.new(profile, fields: Fields::Collection.new(namely_connection))
+    end
   end
 
   def namely_fields_by_label

--- a/spec/models/bulk_sync_spec.rb
+++ b/spec/models/bulk_sync_spec.rb
@@ -21,6 +21,7 @@ describe BulkSync do
           installation: installation
         )
         stub_namely_data("/profiles", "profiles_with_net_suite_fields")
+        stub_namely_fields("fields_with_net_suite")
         stub_request(:put, %r{.*api/v1/profiles/.*}).to_return(status: 200)
         stub_request(:get, %r{.*/api-v2/hubs/erp/employees}).
           to_return(status: 200, body: [{ "internalId" => "123" }].to_json)

--- a/spec/models/fields/collection_spec.rb
+++ b/spec/models/fields/collection_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+describe Fields::Collection do
+  describe "#new" do
+    %w(email longtext referenceselect select text).each do |type|
+      context "for a #{type} field" do
+        it "returns a string value" do
+          result = export(type: type, value: "expected value")
+
+          expect(result).to be_a(Fields::StringValue)
+          expect(result.to_raw).to eq("expected value")
+        end
+      end
+    end
+
+    context "for a referencehistory field" do
+      it "returns a record value" do
+        result = export(
+          type: "referencehistory",
+          value: { id: "expected value" }
+        )
+
+        expect(result).to be_a(Fields::RecordValue)
+        expect(result.to_raw).to eq(id: "expected value")
+      end
+    end
+
+    describe "for a date value" do
+      it "parses into a date object" do
+        result = export(type: "date", value: "08/26/1986")
+
+        expect(result.to_date).to eq(Date.new(1986, 8, 26))
+      end
+    end
+
+    context "for a nil value" do
+      it "returns nil" do
+        result = export(type: "text", value: nil)
+
+        expect(result).to be_nil
+      end
+    end
+
+    context "for an unknown field" do
+      it "returns nil" do
+        namely_connection = stub_connection_with_field(
+          name: "example",
+          type: "text"
+        )
+        collection = Fields::Collection.new(namely_connection)
+        profile = { "unknown" => "value" }
+
+        result = collection.export("unknown", from: profile)
+
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  def export(type:, value:)
+    namely_connection = stub_connection_with_field(
+      name: "example",
+      type: type,
+    )
+    collection = Fields::Collection.new(namely_connection)
+    profile = { "example" => value }
+
+    collection.export("example", from: profile)
+  end
+
+  def stub_connection_with_field(name:, type:)
+    double(:namely_connection).tap do |namely_connection|
+      all_fields = [double(:field, type: type, name: name)]
+      fields = double(:fields, all: all_fields)
+      allow(namely_connection).to receive(:fields).and_return(fields)
+    end
+  end
+end

--- a/spec/models/fields/date_value_spec.rb
+++ b/spec/models/fields/date_value_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe Fields::DateValue do
+  describe "#to_raw" do
+    it "returns the original value" do
+      expect(Fields::DateValue.new(5).to_raw).to eq(5)
+    end
+  end
+
+  describe "#to_s" do
+    it "returns the original value as a string" do
+      expect(Fields::DateValue.new(5).to_s).to eq("5")
+    end
+  end
+
+  describe "#to_date" do
+    it "parses a Namely date string" do
+      expect(Fields::DateValue.new("08/26/1986").to_date).
+        to eq(Date.new(1986, 8, 26))
+    end
+  end
+end

--- a/spec/models/fields/record_value_spec.rb
+++ b/spec/models/fields/record_value_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe Fields::RecordValue do
+  describe "#to_s" do
+    it "finds the value of the first, non-id key" do
+      expect(Fields::RecordValue.new("id" => "x", "title" => "expected").to_s).
+        to eq("expected")
+    end
+  end
+
+  describe "#to_raw" do
+    it "returns the original value" do
+      expect(Fields::RecordValue.new(5).to_raw).to eq(5)
+    end
+  end
+
+  describe "#to_date" do
+    it "returns nil" do
+      expect(Fields::RecordValue.new("08/26/1986").to_date).
+        to be_nil
+    end
+  end
+end

--- a/spec/models/fields/string_value_spec.rb
+++ b/spec/models/fields/string_value_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe Fields::StringValue do
+  describe "#to_s" do
+    it "returns the original value as a string" do
+      expect(Fields::StringValue.new(1).to_s).to eq("1")
+    end
+  end
+
+  describe "#to_raw" do
+    it "returns the original value" do
+      expect(Fields::StringValue.new(5).to_raw).to eq(5)
+    end
+  end
+
+  describe "#to_date" do
+    it "returns nil" do
+      expect(Fields::StringValue.new("08/26/1986").to_date).
+        to be_nil
+    end
+  end
+end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -2,63 +2,37 @@ require "rails_helper"
 
 describe Profile do
   describe "delegations" do
-    subject { Profile.new(stub_profile_data) }
+    subject { Profile.new({}, fields: double(:fields)) }
     it { should delegate_method(:update).to(:namely_profile) }
   end
 
   describe "#[]" do
-    context "with a hash" do
-      it "finds the value of the first, non-id key" do
-        profile = Profile.new(
-          "job_title" => {
-            "id" => "x",
-            "title" => "expected",
-          }
-        )
+    it "exports a value from its fields" do
+      data = double(:data)
+      fields = double(:fields)
+      value = double(:value)
+      allow(fields).
+        to receive(:export).
+        with("job_title", from: data).
+        and_return(value)
+      profile = Profile.new(data, fields: fields)
 
-        result = profile["job_title"]
+      result = profile["job_title"]
 
-        expect(result).to eq("expected")
-      end
-    end
-
-    context "with other types" do
-      it "returns the original value" do
-        profile = Profile.new("name" => "expected")
-
-        result = profile["name"]
-
-        expect(result).to eq("expected")
-      end
+      expect(result).to eq(value)
     end
   end
 
   describe "#name" do
     it "returns #first_name #last_name" do
-      profile_data = stub_profile_data.merge(
+      profile_data = {
         first_name: "First",
         last_name: "Last"
-      )
-      profile = Profile.new(profile_data)
+      }
+      fields = double(:fields)
+      profile = Profile.new(profile_data, fields: fields)
 
       expect(profile.name).to eq("First Last")
     end
-  end
-
-  def stub_profile_data
-    {
-      email: "test@example.com",
-      first_name: "First",
-      last_name: "Last",
-    }.merge(stub_job_title)
-  end
-
-  def stub_job_title(title = "Developer")
-    {
-      job_title: {
-        "id" => "1234",
-        "title" => title
-      }
-    }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -42,13 +42,15 @@ describe User do
     it "returns profiles from its Namely connection" do
       first_names = %w(Alice Bob)
       profile_list = first_names.map { |name| stub_namely_profile(name) }
+      field_list = [double(:field, name: "first_name", type: "text")]
 
       profiles = double(:namely_profiles, all: profile_list)
-      stub_namely_connection profiles: profiles
+      fields = double(:namely_fields, all: field_list)
+      stub_namely_connection profiles: profiles, fields: fields
       user = User.new
 
       profile_first_names = user.namely_profiles.map do |profile|
-        profile[:first_name]
+        profile["first_name"].to_raw
       end
 
       expect(profile_first_names).to match_array(first_names)
@@ -126,7 +128,7 @@ describe User do
   end
 
   def stub_namely_profile(first_name)
-    { first_name: first_name }
+    { "first_name" => first_name }
   end
 
   def stub_namely_connection(attributes)


### PR DESCRIPTION
Because:

* We need to export complex types like addresses and references
* The format for those types varies between services

This commit:

* Extends our type conversion to track Namely types

Notes:

* This refactoring is a prerequisite for properly exporting addresses
* This doesn't modify imports, as those are not relevant for NetSuite

https://trello.com/c/7ucossFw