### PR TITLE
Add activity feed for NetSuite syncs

### DIFF
--- a/app/assets/stylesheets/_activity-feed.scss
+++ b/app/assets/stylesheets/_activity-feed.scss
@@ -1,0 +1,25 @@
+.sync-summary {
+  border-bottom: 1px solid $grey-25;
+  margin-bottom: 20px;
+  padding: 20px 0;
+
+  h2 {
+    font-size: 16px;
+    margin-bottom: 10px;
+  }
+
+  time {
+    color: $grey-50;
+    float: right;
+  }
+
+  li {
+    color: $grey-25;
+    list-style: inside disc;
+  }
+
+  .name {
+    color: $grey-75;
+    font-weight: bold;
+  }
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,4 +11,5 @@
 @import "tables";
 @import "forms";
 @import "dashboard";
+@import "activity-feed";
 @import "sign-in";

--- a/app/controllers/activity_feeds_controller.rb
+++ b/app/controllers/activity_feeds_controller.rb
@@ -1,0 +1,5 @@
+class ActivityFeedsController < IntegrationController
+  def show
+    @sync_summaries = connection.sync_summaries
+  end
+end

--- a/app/jobs/sync_job.rb
+++ b/app/jobs/sync_job.rb
@@ -18,13 +18,11 @@ class SyncJob
   end
 
   def deliver_sync_notification(results)
-    installation.users.each do |user|
-      SyncMailer.sync_notification(
-        email: user.email,
-        integration_id: integration_id,
-        results: results
-      ).deliver_now
-    end
+    SyncNotifier.deliver(
+      results: results,
+      installation: installation,
+      integration_id: integration_id
+    )
   end
 
   def notifier

--- a/app/models/greenhouse/connection.rb
+++ b/app/models/greenhouse/connection.rb
@@ -41,6 +41,10 @@ module Greenhouse
       false
     end
 
+    def has_activity_feed?
+      false
+    end
+
     def required_namely_field
       "greenhouse_id"
     end

--- a/app/models/icims/connection.rb
+++ b/app/models/icims/connection.rb
@@ -32,6 +32,10 @@ module Icims
       false
     end
 
+    def has_activity_feed?
+      false
+    end
+
     def required_namely_field
       Normalizer.new.namely_identifier_field.to_s
     end

--- a/app/models/jobvite/connection.rb
+++ b/app/models/jobvite/connection.rb
@@ -29,6 +29,10 @@ module Jobvite
       false
     end
 
+    def has_activity_feed?
+      false
+    end
+
     def attribute_mapper
       AttributeMapperFactory.new(attribute_mapper: super, connection: self).
         build_with_defaults do |mappings|

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -1,6 +1,7 @@
 class NetSuite::Connection < ActiveRecord::Base
   belongs_to :attribute_mapper, dependent: :destroy
   belongs_to :installation
+  has_many :sync_summaries, as: :connection
 
   validates :subsidiary_id, presence: true, allow_nil: true
 
@@ -28,6 +29,10 @@ class NetSuite::Connection < ActiveRecord::Base
 
   def configurable?
     !subsidiary_optional?
+  end
+
+  def has_activity_feed?
+    true
   end
 
   def attribute_mapper

--- a/app/models/profile_event.rb
+++ b/app/models/profile_event.rb
@@ -1,0 +1,13 @@
+class ProfileEvent < ActiveRecord::Base
+  belongs_to :sync_summary
+
+  # Intended to be called via the association from a SyncSummary which will
+  # provide the required `sync_summary_id` attribute.
+  def self.create_from_result!(result)
+    create!(profile_name: result.name, successful: result.success?)
+  end
+
+  def self.ordered
+    order(profile_name: :asc)
+  end
+end

--- a/app/models/sync_notifier.rb
+++ b/app/models/sync_notifier.rb
@@ -1,0 +1,49 @@
+class SyncNotifier
+  def self.deliver(installation:, integration_id:, results:)
+    new(
+      installation: installation,
+      integration_id: integration_id,
+      results: results
+    ).deliver
+  end
+
+  def initialize(installation:, integration_id:, results:)
+    @installation = installation
+    @integration_id = integration_id
+    @results = results
+  end
+
+  def deliver
+    deliver_emails
+    record_sync_summary
+  end
+
+  private
+
+  attr_reader :installation, :integration_id, :results
+
+  def deliver_emails
+    users.each do |user|
+      SyncMailer.sync_notification(
+        email: user.email,
+        integration_id: integration_id,
+        results: results
+      ).deliver_now
+    end
+  end
+
+  def record_sync_summary
+    SyncSummary.create_from_results!(
+      connection: connection,
+      results: results
+    )
+  end
+
+  def users
+    installation.users
+  end
+
+  def connection
+    installation.connection_to(integration_id)
+  end
+end

--- a/app/models/sync_summary.rb
+++ b/app/models/sync_summary.rb
@@ -1,0 +1,18 @@
+class SyncSummary < ActiveRecord::Base
+  belongs_to :connection, polymorphic: true
+  has_many :profile_events, dependent: :destroy
+
+  def self.create_from_results!(results:, connection:)
+    transaction do
+      create!(connection: connection).tap do |sync_summary|
+        sync_summary.convert_results_to_profile_events(results)
+      end
+    end
+  end
+
+  def convert_results_to_profile_events(results)
+    results.each do |result|
+      profile_events.create_from_result!(result)
+    end
+  end
+end

--- a/app/views/activity_feeds/show.html.erb
+++ b/app/views/activity_feeds/show.html.erb
@@ -1,0 +1,8 @@
+<section id="subheader">
+  <h1><%= t(".title", integration: integration_name) %></h2>
+  <p><%= t(".slogan", integration: integration_name) %></p>
+</section>
+
+<section>
+  <%= render @sync_summaries %>
+</section>

--- a/app/views/dashboards/_edit_actions.html.erb
+++ b/app/views/dashboards/_edit_actions.html.erb
@@ -12,6 +12,10 @@
       edit_integration_mapping_path(connection.integration_id) %></li>
   <% end %>
 
+  <% if connection.has_activity_feed? %>
+    <li><%= link_to t("dashboards.show.activity_feed"),
+      integration_activity_feed_path(connection.integration_id) %></li>
+  <% end %>
 
   <% if connection.found_namely_field? %>
     <li>

--- a/app/views/profile_events/_profile_event.html.erb
+++ b/app/views/profile_events/_profile_event.html.erb
@@ -1,0 +1,1 @@
+<li><span class="name"><%= profile_event.profile_name %></span></li>

--- a/app/views/sync_summaries/_sync_summary.html.erb
+++ b/app/views/sync_summaries/_sync_summary.html.erb
@@ -1,0 +1,17 @@
+<article class="sync-summary">
+  <div class="sync-header">
+    <%= time_tag(
+      sync_summary.created_at,
+      t(
+        "sync_summary.time",
+        duration: time_ago_in_words(sync_summary.created_at)
+      )
+    ) %>
+    <h2>
+      <%= t "sync_summary.heading", count: sync_summary.profile_events.count %>
+    </h2>
+    <ol>
+      <%= render sync_summary.profile_events.ordered %>
+    </ol>
+  </div>
+</article>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
 
   dashboards:
     show:
+      activity_feed: View Activity Feed
       connect: "Connect"
       disconnect: "Disconnect"
       edit_configuration: Edit Configuration
@@ -56,6 +57,18 @@ en:
     show:
       sign_in:
         prompt: "Sign in using"
+
+  activity_feeds:
+    show:
+      title: "%{integration}: Activity Feed"
+      slogan: >
+        Below is a history of synchronization attempts with %{integration}.
+
+  sync_summary:
+    heading:
+      one: "Successfully synced one profile:"
+      other: "Successfully synced %{count} profiles:"
+    time: "%{duration} ago"
 
   candidate_import_mailer:
     successful_import:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   resource :session, only: [:new, :destroy]
 
   resources :integrations, only: [] do
+    resource :activity_feed, only: :show
     resource :authentication, only: [:new, :create, :edit, :update]
     resource :connection, only: [:edit, :update, :destroy]
     resource :sync, only: [:create]

--- a/db/migrate/20150901205306_create_sync_summaries_and_profile_events.rb
+++ b/db/migrate/20150901205306_create_sync_summaries_and_profile_events.rb
@@ -1,0 +1,14 @@
+class CreateSyncSummariesAndProfileEvents < ActiveRecord::Migration
+  def change
+    create_table :sync_summaries do |t|
+      t.references :connection, polymorphic: true, null: false, index: true
+      t.timestamps null: false
+    end
+
+    create_table :profile_events do |t|
+      t.references :sync_summary, null: false, index: true
+      t.string :profile_name, null: false
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150902134111_add_successful_to_profile_events.rb
+++ b/db/migrate/20150902134111_add_successful_to_profile_events.rb
@@ -1,0 +1,5 @@
+class AddSuccessfulToProfileEvents < ActiveRecord::Migration
+  def change
+    add_column :profile_events, :successful, :boolean, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150827155439) do
+ActiveRecord::Schema.define(version: 20150902134111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,6 +118,25 @@ ActiveRecord::Schema.define(version: 20150827155439) do
 
   add_index "net_suite_connections", ["attribute_mapper_id"], name: "index_net_suite_connections_on_attribute_mapper_id", using: :btree
   add_index "net_suite_connections", ["installation_id"], name: "index_net_suite_connections_on_installation_id", using: :btree
+
+  create_table "profile_events", force: :cascade do |t|
+    t.integer  "sync_summary_id", null: false
+    t.string   "profile_name",    null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.boolean  "successful",      null: false
+  end
+
+  add_index "profile_events", ["sync_summary_id"], name: "index_profile_events_on_sync_summary_id", using: :btree
+
+  create_table "sync_summaries", force: :cascade do |t|
+    t.integer  "connection_id",   null: false
+    t.string   "connection_type", null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "sync_summaries", ["connection_type", "connection_id"], name: "index_sync_summaries_on_connection_type_and_connection_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at",                                                      null: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,6 +21,12 @@ FactoryGirl.define do
     trait :with_namely_field do
       found_namely_field true
     end
+
+    trait :ready do
+      connected
+      with_namely_field
+      subsidiary_id "45z"
+    end
   end
 
   factory :icims_connection, class: "Icims::Connection" do
@@ -73,6 +79,10 @@ FactoryGirl.define do
     end
   end
 
+  factory :sync_summary do
+    association :connection, factory: :net_suite_connection
+  end
+
   factory :user do
     sequence(:namely_user_id) { |n| "NAMELY-USER-#{n}" }
     subdomain { installation.subdomain }
@@ -89,5 +99,11 @@ FactoryGirl.define do
     factory :fixed_subdomain_installation do
       subdomain ENV.fetch("TEST_NAMELY_SUBDOMAIN")
     end
+  end
+
+  factory :profile_event do
+    sync_summary
+    profile_name "Example Name"
+    successful true
   end
 end

--- a/spec/features/user_views_activity_feed_spec.rb
+++ b/spec/features/user_views_activity_feed_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+feature "User views activity feed" do
+  scenario "with successful syncs" do
+    user = create(:user)
+    connection = create(
+      :net_suite_connection,
+      :ready,
+      installation: user.installation
+    )
+    sync_summary = create(:sync_summary, connection: connection)
+    create(:profile_event, sync_summary: sync_summary, profile_name: "Adam")
+    create(:profile_event, sync_summary: sync_summary, profile_name: "Ali")
+    create(:profile_event, sync_summary: sync_summary, profile_name: "Amy")
+
+    visit dashboard_path(as: user)
+    find(".net-suite-account").click_link(t("dashboards.show.activity_feed"))
+
+    expect(page).to have_text("Successfully synced 3 profiles")
+    expect(page).to have_text("Adam")
+    expect(page).to have_text("Ali")
+    expect(page).to have_text("Amy")
+  end
+end

--- a/spec/models/profile_event_spec.rb
+++ b/spec/models/profile_event_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe ProfileEvent do
+  describe ".ordered" do
+    it "orders alphabetically by profile name" do
+      create(:profile_event, profile_name: "NameA")
+      create(:profile_event, profile_name: "NameC")
+      create(:profile_event, profile_name: "NameB")
+
+      result = ProfileEvent.ordered
+
+      expect(result.map(&:profile_name)).to eq(%w(NameA NameB NameC))
+    end
+  end
+
+  describe ".create_from_result!" do
+    context "with a successful result" do
+      it "creates a successful profile event" do
+        sync_summary = create(:sync_summary)
+        result = double(:result, name: "Name", success?: true)
+
+        profile_event = sync_summary.profile_events.create_from_result!(result)
+
+        expect(profile_event).to be_persisted
+        expect(profile_event).to be_successful
+      end
+    end
+
+    context "with an unsuccessful result" do
+      it "creates an unsuccessful profile event" do
+        sync_summary = create(:sync_summary)
+        result = double(:result, name: "Name", success?: false)
+
+        profile_event = sync_summary.profile_events.create_from_result!(result)
+
+        expect(profile_event).to be_persisted
+        expect(profile_event).not_to be_successful
+      end
+    end
+  end
+end

--- a/spec/models/sync_notifier_spec.rb
+++ b/spec/models/sync_notifier_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe SyncNotifier do
+  describe ".deliver" do
+    it "sends an email to each user on the installation" do
+      user = build_stubbed(:user)
+      connection = double(:connection)
+      installation = build_stubbed(:installation, users: [user])
+      integration_id = double(:integration_id)
+      allow(installation).
+        to receive(:connection_to).
+        with(integration_id).
+        and_return(connection)
+      results = double(:results)
+      mail = double(SyncMailer, deliver_now: true)
+      allow(SyncSummary).
+        to receive(:create_from_results!)
+      allow(SyncMailer).
+        to receive(:sync_notification).
+        and_return(mail)
+
+      SyncNotifier.deliver(
+        installation: installation,
+        integration_id: integration_id,
+        results: results,
+      )
+
+      expect(SyncMailer).to have_received(:sync_notification).
+        with(
+          email: user.email,
+          integration_id: integration_id,
+          results: results
+        )
+      expect(mail).to have_received(:deliver_now)
+      expect(SyncSummary).to have_received(:create_from_results!).with(
+        connection: connection,
+        results: results
+      )
+    end
+  end
+end

--- a/spec/models/sync_summary_spec.rb
+++ b/spec/models/sync_summary_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe SyncSummary do
+  describe ".create_from_results" do
+    it "creates a sync summary for the connection with the given results" do
+      names = %w(Billy Wendy Franko)
+      results = names.map { |name| double(:result, name: name, success?: true) }
+      connection = create(:net_suite_connection)
+
+      summary = SyncSummary.create_from_results!(
+        results: results,
+        connection: connection
+      )
+
+      expect(summary).to be_persisted
+      expect(summary.profile_events.pluck(:profile_name)).to match_array(names)
+    end
+  end
+end


### PR DESCRIPTION
This gives users a web-accessible view of the sync activity happening
with their net suite integration. The data is similar to what is emailed
to them.

The view currently does not distinguish between successful or
unsuccessful profile events, but we have a follow-on task that will take
care of that.

https://trello.com/c/WsHL9kNH