### PR TITLE
Update db/schema.rb for Rails 4.2

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,121 +16,121 @@ ActiveRecord::Schema.define(version: 20150827155439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "attribute_mappers", force: true do |t|
+  create_table "attribute_mappers", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "delayed_jobs", force: true do |t|
-    t.integer  "priority",   default: 0, null: false
-    t.integer  "attempts",   default: 0, null: false
-    t.text     "handler",                null: false
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",               default: 0, null: false
+    t.integer  "attempts",               default: 0, null: false
+    t.text     "handler",                            null: false
     t.text     "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string   "locked_by",  limit: 255
+    t.string   "queue",      limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
-  create_table "export_logs", force: true do |t|
-    t.integer  "connection_id",   null: false
-    t.string   "connection_type", null: false
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+  create_table "export_logs", force: :cascade do |t|
+    t.integer  "connection_id",               null: false
+    t.string   "connection_type", limit: 255, null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
   end
 
   add_index "export_logs", ["connection_id", "connection_type"], name: "index_export_logs_on_connection_id_and_connection_type", using: :btree
 
-  create_table "field_mappings", force: true do |t|
-    t.string   "integration_field_name", null: false
-    t.string   "namely_field_name"
-    t.integer  "attribute_mapper_id",    null: false
+  create_table "field_mappings", force: :cascade do |t|
+    t.string   "integration_field_name", limit: 255, null: false
+    t.string   "namely_field_name",      limit: 255
+    t.integer  "attribute_mapper_id",                null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "integration_field_id",   null: false
+    t.string   "integration_field_id",   limit: 255, null: false
   end
 
   add_index "field_mappings", ["attribute_mapper_id"], name: "index_field_mappings_on_attribute_mapper_id", using: :btree
 
-  create_table "greenhouse_connections", force: true do |t|
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.string   "secret_key"
-    t.string   "name"
-    t.boolean  "found_namely_field",  default: false, null: false
-    t.integer  "installation_id",                     null: false
+  create_table "greenhouse_connections", force: :cascade do |t|
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+    t.string   "secret_key",          limit: 255
+    t.string   "name",                limit: 255
+    t.boolean  "found_namely_field",              default: false, null: false
+    t.integer  "installation_id",                                 null: false
     t.integer  "attribute_mapper_id"
   end
 
   add_index "greenhouse_connections", ["installation_id"], name: "index_greenhouse_connections_on_installation_id", using: :btree
 
-  create_table "icims_connections", force: true do |t|
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
-    t.string   "username"
+  create_table "icims_connections", force: :cascade do |t|
+    t.datetime "created_at",                                     null: false
+    t.datetime "updated_at",                                     null: false
+    t.string   "username",           limit: 255
     t.integer  "customer_id"
-    t.boolean  "found_namely_field", default: false, null: false
-    t.string   "key"
-    t.string   "api_key"
-    t.integer  "installation_id",                    null: false
+    t.boolean  "found_namely_field",             default: false, null: false
+    t.string   "key",                limit: 255
+    t.string   "api_key",            limit: 255
+    t.integer  "installation_id",                                null: false
   end
 
   add_index "icims_connections", ["installation_id"], name: "index_icims_connections_on_installation_id", using: :btree
 
-  create_table "installations", force: true do |t|
-    t.string   "subdomain",  null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table "installations", force: :cascade do |t|
+    t.string   "subdomain",  limit: 255, null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   add_index "installations", ["subdomain"], name: "index_installations_on_subdomain", unique: true, using: :btree
 
-  create_table "jobvite_connections", force: true do |t|
-    t.string   "api_key"
-    t.string   "secret"
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
-    t.string   "hired_workflow_state", default: "Offer Accepted", null: false
-    t.boolean  "found_namely_field",   default: false,            null: false
+  create_table "jobvite_connections", force: :cascade do |t|
+    t.string   "api_key",              limit: 255
+    t.string   "secret",               limit: 255
+    t.datetime "created_at",                                                  null: false
+    t.datetime "updated_at",                                                  null: false
+    t.string   "hired_workflow_state", limit: 255, default: "Offer Accepted", null: false
+    t.boolean  "found_namely_field",               default: false,            null: false
     t.integer  "attribute_mapper_id"
-    t.integer  "installation_id",                                 null: false
+    t.integer  "installation_id",                                             null: false
   end
 
   add_index "jobvite_connections", ["attribute_mapper_id"], name: "index_jobvite_connections_on_attribute_mapper_id", using: :btree
   add_index "jobvite_connections", ["installation_id"], name: "index_jobvite_connections_on_installation_id", using: :btree
 
-  create_table "net_suite_connections", force: true do |t|
-    t.string   "instance_id"
-    t.string   "authorization"
+  create_table "net_suite_connections", force: :cascade do |t|
+    t.string   "instance_id",         limit: 255
+    t.string   "authorization",       limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "found_namely_field",  default: false, null: false
-    t.string   "subsidiary_id"
+    t.boolean  "found_namely_field",              default: false, null: false
+    t.string   "subsidiary_id",       limit: 255
     t.integer  "attribute_mapper_id"
-    t.integer  "installation_id",                     null: false
+    t.integer  "installation_id",                                 null: false
     t.boolean  "subsidiary_required"
   end
 
   add_index "net_suite_connections", ["attribute_mapper_id"], name: "index_net_suite_connections_on_attribute_mapper_id", using: :btree
   add_index "net_suite_connections", ["installation_id"], name: "index_net_suite_connections_on_installation_id", using: :btree
 
-  create_table "users", force: true do |t|
-    t.datetime "created_at",                                          null: false
-    t.datetime "updated_at",                                          null: false
-    t.string   "namely_user_id",                                      null: false
-    t.string   "access_token",                                        null: false
-    t.string   "refresh_token",                                       null: false
-    t.string   "subdomain",                                           null: false
-    t.string   "first_name"
-    t.string   "last_name"
-    t.datetime "access_token_expiry", default: '1970-01-01 00:00:00', null: false
-    t.string   "email"
-    t.integer  "installation_id",                                     null: false
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at",                                                      null: false
+    t.datetime "updated_at",                                                      null: false
+    t.string   "namely_user_id",      limit: 255,                                 null: false
+    t.string   "access_token",        limit: 255,                                 null: false
+    t.string   "refresh_token",       limit: 255,                                 null: false
+    t.string   "subdomain",           limit: 255,                                 null: false
+    t.string   "first_name",          limit: 255
+    t.string   "last_name",           limit: 255
+    t.datetime "access_token_expiry",             default: '1970-01-01 00:00:00', null: false
+    t.string   "email",               limit: 255
+    t.integer  "installation_id",                                                 null: false
   end
 
   add_index "users", ["installation_id"], name: "index_users_on_installation_id", using: :btree


### PR DESCRIPTION
Rails 4.2 schema dumper has some changes from Rails 4.1. This change
contains is the result of `rake db:schema:dump` under Rails 4.2.