### PR TITLE
Instantiate SyncJob with a connection

### DIFF
--- a/app/controllers/syncs_controller.rb
+++ b/app/controllers/syncs_controller.rb
@@ -1,8 +1,5 @@
 class SyncsController < IntegrationController
   def create
-    Delayed::Job.enqueue(
-      SyncJob.new(integration_id, current_user.installation_id)
-    )
-    connection
+    SyncJob.perform_later(connection)
   end
 end

--- a/app/models/bulk_sync.rb
+++ b/app/models/bulk_sync.rb
@@ -9,8 +9,9 @@ class BulkSync
   end
 
   def sync
-    @installations.ready_to_sync_with(@integration_id).each do |installations|
-      Delayed::Job.enqueue SyncJob.new(@integration_id, installations.id)
+    @installations.ready_to_sync_with(@integration_id).each do |installation|
+      connection = installation.connection_to(@integration_id)
+      SyncJob.perform_later(connection)
     end
   end
 end

--- a/spec/jobs/sync_job_spec.rb
+++ b/spec/jobs/sync_job_spec.rb
@@ -2,67 +2,41 @@ require "rails_helper"
 
 describe SyncJob do
   describe "#perform" do
-    it "runs and export and emails the results" do
+    it "runs an export and emails the results" do
+      connection = build_stubbed(:net_suite_connection)
       results = double(:results)
-      net_suite_connection = double(NetSuite::Connection, sync: results)
-      installation = double(
-        Installation,
-        net_suite_connection: net_suite_connection,
-      )
-      installation_id = double(:installation_id)
+      allow(connection).to receive(:sync).and_return(results)
       allow(SyncNotifier).to receive(:deliver)
-      allow(Installation).
-        to receive(:find).
-        with(installation_id).
-        and_return(installation)
-      integration_id = "net_suite"
-      job = SyncJob.new(integration_id, installation_id)
 
-      job.perform
+      SyncJob.perform_now(connection)
 
-      expect(net_suite_connection).to have_received(:sync)
+      expect(connection).to have_received(:sync)
       expect(SyncNotifier).
         to have_received(:deliver).
         with(
           results: results,
-          integration_id: integration_id,
-          installation: installation
+          integration_id: connection.integration_id,
+          installation: connection.installation
         )
     end
   end
 
   context "authentication failure" do
     it "traps exception and alerts the user" do
-      net_suite_connection = double(NetSuite::Connection)
-      installation = double(
-        Installation,
-        id: 1,
-        net_suite_connection: net_suite_connection,
-      )
-      installation_id = double(:installation_id)
+      connection = build_stubbed(:net_suite_connection)
       exception = Unauthorized.new("An error message")
-      allow(net_suite_connection).to receive(:sync).
-        and_raise(exception)
-      integration_id = "net_suite"
-      allow(Installation).
-        to receive(:find).
-        with(installation_id).
-        and_return(installation)
-      allow(installation).to receive(:send_connection_notification).with(
-        integration_id: integration_id,
+      installation = connection.installation
+      allow(connection).to receive(:sync).and_raise(exception)
+      allow(installation).to receive(:send_connection_notification)
+      allow(Rails.logger).to receive(:error)
+
+      SyncJob.perform_now(connection)
+
+      expect(Rails.logger).to have_received(:error).with(/Unauthorized error/)
+      expect(installation).to have_received(:send_connection_notification).with(
+        integration_id: connection.integration_id,
         message: exception.message
       )
-      job = SyncJob.new(integration_id, installation_id)
-
-      expect(Rails.logger).to receive(:error).with(
-        "Unauthorized error An error message for installation_id: " \
-        "#{installation.id} with NetSuite"
-      )
-
-      job.perform
-
-      expect(installation).to have_received(:send_connection_notification).
-        with(integration_id: integration_id, message: exception.message)
     end
   end
 end

--- a/spec/support/background_jobs.rb
+++ b/spec/support/background_jobs.rb
@@ -9,17 +9,11 @@ module BackgroundJobs
 end
 
 RSpec.configure do |config|
-  config.around(:each, type: :feature) do |example|
-    run_background_jobs_immediately do
-      example.run
-    end
-  end
-
   config.around(:each, type: :request) do |example|
     run_background_jobs_immediately do
       example.run
     end
   end
 
-  config.include BackgroundJobs
+  config.include(BackgroundJobs, type: :request)
 end


### PR DESCRIPTION
This previously took two arguments, both of which are accessible via the
connection. We had convenient access to the connection in all places
where we were instantiating Sync Jobs.