### PR TITLE
Fail faster when interacting with Cloud Elements

### DIFF
--- a/app/models/net_suite/api_error.rb
+++ b/app/models/net_suite/api_error.rb
@@ -1,0 +1,25 @@
+module NetSuite
+  # Wraps BadRequest errors from Cloud Elements. Attempts to parse a
+  # human-readable error message from the response.
+  class ApiError < StandardError
+    def initialize(response)
+      @response = response
+    end
+
+    def message
+      response_data["providerMessage"] ||
+        response_data["message"] ||
+        "Unknown error"
+    end
+
+    private
+
+    def response_data
+      if @response.present?
+        JSON.parse(@response)
+      else
+        {}
+      end
+    end
+  end
+end

--- a/app/models/net_suite/authentication.rb
+++ b/app/models/net_suite/authentication.rb
@@ -26,16 +26,14 @@ module NetSuite
 
     def create_instance
       result = @client.create_instance(self)
-      if result.success?
-        @connection.update!(
-          instance_id: result[:id],
-          authorization: result[:token]
-        )
-        true
-      else
-        errors.add(:base, result[:message])
-        false
-      end
+      @connection.update!(
+        instance_id: result["id"],
+        authorization: result["token"]
+      )
+      true
+    rescue NetSuite::ApiError => exception
+      errors.add(:base, exception.message)
+      false
     end
 
     def attributes

--- a/app/models/net_suite/client/request.rb
+++ b/app/models/net_suite/client/request.rb
@@ -10,7 +10,7 @@ module NetSuite
       end
 
       def submit_json(method, path, data)
-        wrap_response do
+        translate_response do
           RestClient.public_send(
             method,
             url(path),
@@ -22,7 +22,7 @@ module NetSuite
       end
 
       def get_json(path)
-        wrap_response do
+        translate_response do
           RestClient.get(
             url(path),
             authorization: authorization,
@@ -33,11 +33,13 @@ module NetSuite
 
       private
 
-      def wrap_response
+      def translate_response
         response = yield
-        Result.new(true, response)
+        if response.present?
+          JSON.parse(response)
+        end
       rescue RestClient::BadRequest => exception
-        Result.new(false, exception.response)
+        raise NetSuite::ApiError, exception.response
       rescue RestClient::Unauthorized => exception
         raise Unauthorized, exception.message
       end

--- a/spec/models/net_suite/api_error_spec.rb
+++ b/spec/models/net_suite/api_error_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+describe NetSuite::ApiError do
+  describe "#message" do
+    context "with a JSON message" do
+      it "returns the encoded message" do
+        message = "Error"
+        error = NetSuite::ApiError.new({ "providerMessage" => message }.to_json)
+
+        result = error.message
+
+        expect(result).to eq(message)
+      end
+    end
+
+    context "with a JSON provider message" do
+      it "returns the encoded message" do
+        message = "Error"
+        error = NetSuite::ApiError.new({ "message" => message }.to_json)
+
+        result = error.message
+
+        expect(result).to eq(message)
+      end
+    end
+
+    context "with JSON without a message" do
+      it "returns a default message" do
+        error = NetSuite::ApiError.new({}.to_json)
+
+        result = error.message
+
+        expect(result).to eq("Unknown error")
+      end
+    end
+
+    context "with an empty response" do
+      it "returns a default message" do
+        error = NetSuite::ApiError.new(nil)
+
+        result = error.message
+
+        expect(result).to eq("Unknown error")
+      end
+    end
+  end
+end

--- a/spec/models/net_suite/client_spec.rb
+++ b/spec/models/net_suite/client_spec.rb
@@ -77,14 +77,13 @@ describe NetSuite::Client do
 
         result = client.create_instance(authentication)
 
-        expect(result).to be_success
-        expect(result[:id]).to eq instance_response["id"]
-        expect(result[:token]).to eq instance_response["token"]
+        expect(result["id"]).to eq instance_response["id"]
+        expect(result["token"]).to eq instance_response["token"]
       end
     end
 
     context "on HTTP failure" do
-      it "returns failure messages" do
+      it "raises an exception" do
         allow(NetSuite::Instance).to receive(:new).and_return({})
         error = "a failure"
         stub_request(
@@ -98,10 +97,8 @@ describe NetSuite::Client do
           organization_secret: "x"
         )
 
-        result = client.create_instance(double("Authentication"))
-
-        expect(result).not_to be_success
-        expect(result[:message]).to eq(error)
+        expect { client.create_instance(double("Authentication")) }.
+          to raise_error(NetSuite::ApiError)
       end
     end
 
@@ -171,7 +168,6 @@ describe NetSuite::Client do
           title: "CEO"
         )
 
-        expect(result).to be_success
         expect(result["internalId"]).to eq("1949")
       end
     end
@@ -222,7 +218,6 @@ describe NetSuite::Client do
           title: "CEO",
         )
 
-        expect(result).to be_success
         expect(result["internalId"]).to eq("1949")
       end
     end
@@ -251,7 +246,6 @@ describe NetSuite::Client do
 
       result = client.subsidiaries
 
-      expect(result).to be_success
       expect(result.to_a).to eq(subsidiaries)
     end
   end


### PR DESCRIPTION
Because:

* The Cloud Elements API can fail during any request
* We don't have explicit handling for many of these failures

This commit:

* Raises exceptions whenever a request fails
* Wraps known exceptions in a special exception class
* Rescues exceptions in the two places we know how to handle them