### PR TITLE
Display failure messages for failed profiles

### DIFF
--- a/app/assets/stylesheets/_activity-feed.scss
+++ b/app/assets/stylesheets/_activity-feed.scss
@@ -1,11 +1,11 @@
 .sync-summary {
   border-bottom: 1px solid $grey-25;
   margin-bottom: 20px;
-  padding: 20px 0;
+  padding: 0 0 20px;
 
   h2 {
     font-size: 16px;
-    margin-bottom: 10px;
+    margin: 10px 0;
   }
 
   time {

--- a/app/assets/stylesheets/_errors.scss
+++ b/app/assets/stylesheets/_errors.scss
@@ -1,0 +1,12 @@
+.failure {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @extend .fa;
+    @extend .fa-warning;
+    color: $orange;
+  }
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -13,3 +13,4 @@
 @import "dashboard";
 @import "activity-feed";
 @import "sign-in";
+@import "errors";

--- a/app/models/jobvite/connection.rb
+++ b/app/models/jobvite/connection.rb
@@ -85,7 +85,7 @@ module Jobvite
       end
 
       delegate :name, to: :candidate
-      delegate :success?, to: :result
+      delegate :success?, :error, to: :result
 
       private
 

--- a/app/models/net_suite/client/request.rb
+++ b/app/models/net_suite/client/request.rb
@@ -39,6 +39,7 @@ module NetSuite
           JSON.parse(response)
         end
       rescue RestClient::BadRequest => exception
+        Rails.logger.error "Bad Request: #{exception.response}"
         raise NetSuite::ApiError, exception.response
       rescue RestClient::Unauthorized => exception
         raise Unauthorized, exception.message

--- a/app/models/profile_event.rb
+++ b/app/models/profile_event.rb
@@ -4,10 +4,22 @@ class ProfileEvent < ActiveRecord::Base
   # Intended to be called via the association from a SyncSummary which will
   # provide the required `sync_summary_id` attribute.
   def self.create_from_result!(result)
-    create!(profile_name: result.name, successful: result.success?)
+    create!(profile_name: result.name, error: result.error)
   end
 
   def self.ordered
     order(profile_name: :asc)
+  end
+
+  def self.successful
+    where(error: nil)
+  end
+
+  def self.failed
+    where.not(error: nil)
+  end
+
+  def successful?
+    error.nil?
   end
 end

--- a/app/models/successful_candidate_import.rb
+++ b/app/models/successful_candidate_import.rb
@@ -1,4 +1,8 @@
 class SuccessfulCandidateImport
+  def error
+    nil
+  end
+
   def success?
     true
   end

--- a/app/views/profile_events/_profile_event.html.erb
+++ b/app/views/profile_events/_profile_event.html.erb
@@ -1,1 +1,6 @@
-<li><span class="name"><%= profile_event.profile_name %></span></li>
+<li>
+  <span class="name"><%= profile_event.profile_name %></span>
+  <% if profile_event.error? %>
+    <span class="error">(<%= profile_event.error %>)</span>
+  <% end %>
+</li>

--- a/app/views/sync_summaries/_profile_events.html.erb
+++ b/app/views/sync_summaries/_profile_events.html.erb
@@ -1,0 +1,10 @@
+<% if profile_events.any? %>
+  <div class="<%= status %>">
+    <h2>
+      <%= t "sync_summary.#{status}_heading", count: profile_events.count %>
+    </h2>
+    <ol>
+      <%= render profile_events.ordered %>
+    </ol>
+  </div>
+<% end %>

--- a/app/views/sync_summaries/_sync_summary.html.erb
+++ b/app/views/sync_summaries/_sync_summary.html.erb
@@ -7,11 +7,11 @@
         duration: time_ago_in_words(sync_summary.created_at)
       )
     ) %>
-    <h2>
-      <%= t "sync_summary.heading", count: sync_summary.profile_events.count %>
-    </h2>
-    <ol>
-      <%= render sync_summary.profile_events.ordered %>
-    </ol>
+    <%= render "sync_summaries/profile_events",
+      status: "success",
+      profile_events: sync_summary.profile_events.successful %>
+    <%= render "sync_summaries/profile_events",
+      status: "failure",
+      profile_events: sync_summary.profile_events.failed %>
   </div>
 </article>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -25,3 +25,4 @@ ignore_unused:
   - greenhouse_candidate_import_mailer.*
   - "*connections.description.disconnected_html"
   - "*connections.description.connected_html"
+  - "sync_summary.*"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,9 +65,12 @@ en:
         Below is a history of synchronization attempts with %{integration}.
 
   sync_summary:
-    heading:
+    success_heading:
       one: "Successfully synced one profile:"
       other: "Successfully synced %{count} profiles:"
+    failure_heading:
+      one: "Unable to sync one profile:"
+      other: "Unable to sync %{count} profiles:"
     time: "%{duration} ago"
 
   candidate_import_mailer:

--- a/db/migrate/20150902145916_add_error_to_profile_events.rb
+++ b/db/migrate/20150902145916_add_error_to_profile_events.rb
@@ -1,0 +1,19 @@
+class AddErrorToProfileEvents < ActiveRecord::Migration
+  def up
+    add_column :profile_events, :error, :string
+    add_index :profile_events, :error, where: "error IS NULL"
+    update(<<-SQL)
+      UPDATE profile_events SET error = 'Unknown Error' WHERE successful = false
+    SQL
+    remove_column :profile_events, :successful
+  end
+
+  def down
+    add_column :profile_events, :successful, :boolean
+    update(<<-SQL)
+      UPDATE profile_events SET successful = error IS NULL
+    SQL
+    change_column_null :profile_events, :successful, false
+    remove_column :profile_events, :error
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150902134111) do
+ActiveRecord::Schema.define(version: 20150902145916) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,9 +124,10 @@ ActiveRecord::Schema.define(version: 20150902134111) do
     t.string   "profile_name",    null: false
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
-    t.boolean  "successful",      null: false
+    t.string   "error"
   end
 
+  add_index "profile_events", ["error"], name: "index_profile_events_on_error", where: "(error IS NULL)", using: :btree
   add_index "profile_events", ["sync_summary_id"], name: "index_profile_events_on_sync_summary_id", using: :btree
 
   create_table "sync_summaries", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -104,6 +104,5 @@ FactoryGirl.define do
   factory :profile_event do
     sync_summary
     profile_name "Example Name"
-    successful true
   end
 end

--- a/spec/features/user_views_activity_feed_spec.rb
+++ b/spec/features/user_views_activity_feed_spec.rb
@@ -2,23 +2,62 @@ require "rails_helper"
 
 feature "User views activity feed" do
   scenario "with successful syncs" do
+    view_activity_feed do |connection|
+      sync_summary = create(:sync_summary, connection: connection)
+      create(:profile_event, sync_summary: sync_summary, profile_name: "Adam")
+      create(:profile_event, sync_summary: sync_summary, profile_name: "Ali")
+      create(:profile_event, sync_summary: sync_summary, profile_name: "Amy")
+    end
+
+    expect(page).to have_text("Successfully synced 3 profiles")
+    expect(page).to have_text("Adam")
+    expect(page).to have_text("Ali")
+    expect(page).to have_text("Amy")
+  end
+
+  scenario "with some failed profiles" do
+    view_activity_feed do |connection|
+      sync_summary = create(:sync_summary, connection: connection)
+      create(
+        :profile_event,
+        sync_summary: sync_summary,
+        profile_name: "Adam",
+        error: nil
+      )
+      create(
+        :profile_event,
+        sync_summary: sync_summary,
+        profile_name: "Ali",
+        error: "Phone number is invalid"
+      )
+      create(
+        :profile_event,
+        sync_summary: sync_summary,
+        profile_name: "Amy",
+        error: "Email is required"
+      )
+    end
+
+    expect(page).to have_text("Successfully synced one profile")
+    expect(page).to have_text("Adam")
+    expect(page).to have_text("Unable to sync 2 profiles")
+    expect(page).to have_text("Ali")
+    expect(page).to have_text("Phone number is invalid")
+    expect(page).to have_text("Amy")
+    expect(page).to have_text("Email is required")
+  end
+
+  def view_activity_feed
     user = create(:user)
     connection = create(
       :net_suite_connection,
       :ready,
       installation: user.installation
     )
-    sync_summary = create(:sync_summary, connection: connection)
-    create(:profile_event, sync_summary: sync_summary, profile_name: "Adam")
-    create(:profile_event, sync_summary: sync_summary, profile_name: "Ali")
-    create(:profile_event, sync_summary: sync_summary, profile_name: "Amy")
+
+    yield connection
 
     visit dashboard_path(as: user)
     find(".net-suite-account").click_link(t("dashboards.show.activity_feed"))
-
-    expect(page).to have_text("Successfully synced 3 profiles")
-    expect(page).to have_text("Adam")
-    expect(page).to have_text("Ali")
-    expect(page).to have_text("Amy")
   end
 end

--- a/spec/models/sync_summary_spec.rb
+++ b/spec/models/sync_summary_spec.rb
@@ -4,7 +4,7 @@ describe SyncSummary do
   describe ".create_from_results" do
     it "creates a sync summary for the connection with the given results" do
       names = %w(Billy Wendy Franko)
-      results = names.map { |name| double(:result, name: name, success?: true) }
+      results = names.map { |name| double(:result, name: name, error: nil) }
       connection = create(:net_suite_connection)
 
       summary = SyncSummary.create_from_results!(


### PR DESCRIPTION
When a sync fails to export one or more profiles, record the failure
message from the remote service on the profile event and display it in
the feed.

Also separates out failed profile events into their own section in the
feed.

https://trello.com/c/781vB8tU