### PR TITLE
Make Unauthorized and Sync notifiers consistent

### DIFF
--- a/app/jobs/sync_job.rb
+++ b/app/jobs/sync_job.rb
@@ -17,7 +17,9 @@ class SyncJob < ActiveJob::Base
   end
 
   def deliver_unauthorized_notification(connection, exception)
-    UnauthorizedNotifier.new(connection).
-      log_and_notify_of_unauthorized_exception(exception)
+    UnauthorizedNotifier.deliver(
+      connection: connection,
+      exception: exception
+    )
   end
 end

--- a/app/models/unauthorized_notifier.rb
+++ b/app/models/unauthorized_notifier.rb
@@ -1,29 +1,34 @@
 class UnauthorizedNotifier
-  def initialize(connection)
+  def self.deliver(connection:, exception:)
+    new(connection: connection, exception: exception).deliver
+  end
+
+  def initialize(connection:, exception:)
     @connection = connection
+    @exception = exception
   end
 
   def integration_name
     I18n.t("#{integration_id}.name")
   end
 
-  def log_and_notify_of_unauthorized_exception(exception)
-    log_unauthorized_exception(exception)
-    deliver_unauthorized_notification(exception)
+  def deliver
+    log_unauthorized_exception
+    deliver_unauthorized_notification
   end
 
   private
 
-  attr_reader :connection
+  attr_reader :connection, :exception
 
-  def deliver_unauthorized_notification(exception)
+  def deliver_unauthorized_notification
     installation.send_connection_notification(
       integration_id: integration_id,
       message: exception.message
     )
   end
 
-  def log_unauthorized_exception(exception)
+  def log_unauthorized_exception
     Rails.logger.error(
       "#{exception.class} error #{exception.message} for " \
       "installation_id: #{installation.id} with #{integration_name}"

--- a/app/services/candidate_importer.rb
+++ b/app/services/candidate_importer.rb
@@ -36,8 +36,11 @@ class CandidateImporter
     )
   end
 
-  def notifier
-    UnauthorizedNotifier.new(connection)
+  def notify_of_unauthorized_exception(exception)
+    UnauthorizedNotifier.deliver(
+      connection: connection,
+      exception: exception
+    )
   end
 
   def installation

--- a/app/services/greenhouse/candidate_import_assistant.rb
+++ b/app/services/greenhouse/candidate_import_assistant.rb
@@ -73,7 +73,7 @@ module Greenhouse
     def mark_as_error_and_send_notification
       @authentication_error = true
       exception = Unauthorized.new(Unauthorized::DEFAULT_MESSAGE)
-      context.notifier.log_and_notify_of_unauthorized_exception(exception)
+      context.notify_of_unauthorized_exception(exception)
 
       raise exception
     end

--- a/app/services/icims/candidate_import_assistant.rb
+++ b/app/services/icims/candidate_import_assistant.rb
@@ -22,7 +22,7 @@ module Icims
       @import_candidate ||= context.namely_importer.single_import(candidate)
     rescue Icims::Client::Error => exception
       @authentication_error = true
-      context.notifier.log_and_notify_of_unauthorized_exception(exception)
+      context.notify_of_unauthorized_exception(exception)
     end
 
     def success?

--- a/spec/jobs/sync_job_spec.rb
+++ b/spec/jobs/sync_job_spec.rb
@@ -25,18 +25,13 @@ describe SyncJob do
     it "traps exception and alerts the user" do
       connection = build_stubbed(:net_suite_connection)
       exception = Unauthorized.new("An error message")
-      installation = connection.installation
       allow(connection).to receive(:sync).and_raise(exception)
-      allow(installation).to receive(:send_connection_notification)
-      allow(Rails.logger).to receive(:error)
+      allow(UnauthorizedNotifier).to receive(:deliver)
 
       SyncJob.perform_now(connection)
 
-      expect(Rails.logger).to have_received(:error).with(/Unauthorized error/)
-      expect(installation).to have_received(:send_connection_notification).with(
-        integration_id: connection.integration_id,
-        message: exception.message
-      )
+      expect(UnauthorizedNotifier).to have_received(:deliver).
+        with(connection: connection, exception: exception)
     end
   end
 end


### PR DESCRIPTION
Make the two notifiers use the same interface:

* class method `deliver`
* instance method `deliver`