### PR TITLE
Simplify sync notifications

### DIFF
--- a/app/mailers/sync_mailer.rb
+++ b/app/mailers/sync_mailer.rb
@@ -1,63 +1,15 @@
 class SyncMailer < ApplicationMailer
-  def sync_notification(email:, integration_id:, results:)
-    @integration_id = integration_id
-    @sync_results = SyncResults.new(integration_id, results)
+  def sync_notification(email:, sync_summary:)
+    @integration = I18n.t("#{sync_summary.integration_id}.name")
+    @profile_events = sync_summary.profile_events
 
-    mail(to: email, subject: @sync_results.subject)
-  end
-
-  class SyncResults
-    def initialize(integration_id, results)
-      @integration_id = integration_id
-      @results = results
-    end
-
-    def subject
-      t(
+    mail(
+      to: email,
+      subject: t(
         "sync_mailer.sync_notification.subject",
-        employees: employees(succeeded.count)
+        integration: @integration,
+        count: @profile_events.successful.count
       )
-    end
-
-    def succeeded
-      @succeeded ||= @results.select(&:success?)
-    end
-
-    def succeeded_message
-      t(
-        "sync_mailer.sync_notification.succeeded",
-        employees: employees(succeeded.count)
-      )
-    end
-
-    def failed
-      @failed ||= @results.reject(&:success?)
-    end
-
-    def failed_message
-      t(
-        "sync_mailer.sync_notification.failed",
-        employees: employees(failed.count)
-      )
-    end
-
-    def employees(count)
-      t(
-        "sync_mailer.sync_notification.employees",
-        count: count
-      )
-    end
-
-    private
-
-    def t(key, data = {})
-      I18n.t(key, data.merge(integration: integration))
-    end
-
-    def integration
-      I18n.t("#{@integration_id}.name")
-    end
+    )
   end
-
-  private_constant :SyncResults
 end

--- a/app/models/sync_notifier.rb
+++ b/app/models/sync_notifier.rb
@@ -14,21 +14,20 @@ class SyncNotifier
   end
 
   def deliver
-    deliver_emails
-    record_sync_summary
+    sync_summary = record_sync_summary
+    deliver_emails(sync_summary)
   end
 
   private
 
   attr_reader :installation, :integration_id, :results
 
-  def deliver_emails
+  def deliver_emails(sync_summary)
     users.each do |user|
       SyncMailer.sync_notification(
         email: user.email,
-        integration_id: integration_id,
-        results: results
-      ).deliver_now
+        sync_summary: sync_summary
+      ).deliver_later
     end
   end
 

--- a/app/models/sync_summary.rb
+++ b/app/models/sync_summary.rb
@@ -2,6 +2,8 @@ class SyncSummary < ActiveRecord::Base
   belongs_to :connection, polymorphic: true
   has_many :profile_events, dependent: :destroy
 
+  delegate :integration_id, to: :connection
+
   def self.create_from_results!(results:, connection:)
     transaction do
       create!(connection: connection).tap do |sync_summary|

--- a/app/views/sync_mailer/sync_notification.en.text.erb
+++ b/app/views/sync_mailer/sync_notification.en.text.erb
@@ -1,17 +1,25 @@
-<%= @sync_results.succeeded_message %>
+<%= t(
+  "sync_mailer.sync_notification.succeeded",
+  count: @profile_events.successful.count,
+  integration: @integration,
+) %>
 
 <%= t(".succeeded_list") %>
 
-<% @sync_results.succeeded.each do |result| %>
-<%= result.name %>
+<% @profile_events.successful.each do |profile_event| %>
+<%= profile_event.profile_name %>
 <% end -%>
 
-<%= @sync_results.failed_message %>
+<%= t(
+  "sync_mailer.sync_notification.failed",
+  count: @profile_events.failed.count,
+  integration: @integration,
+) %>
 
 <%= t(".failed_list") %>
 
-<% @sync_results.failed.each do |result| %>
-<%= result.name %>
+<% @profile_events.failed.each do |profile_event| %>
+<%= profile_event.profile_name %> (<%= profile_event.error %>)
 <% end -%>
 
 Namely

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -220,13 +220,16 @@ en:
 
   sync_mailer:
     sync_notification:
-      employees:
-        one: "%{count} employee"
-        other: "%{count} employees"
-      failed: "%{employees} not synchronized."
+      failed:
+        one: "%{count} employee not synchronized."
+        other: "%{count} employees not synchronized."
       failed_list: "Here's who wasn't synchronized:"
-      subject: "%{employees} synced with %{integration}"
-      succeeded: "%{employees} synchronized with %{integration} successfully."
+      subject:
+        one: "%{count} employee synced with %{integration}"
+        other: "%{count} employees synced with %{integration}"
+      succeeded:
+        one: "%{count} employee synchronized with %{integration} successfully."
+        other: "%{count} employees synchronized with %{integration} successfully."
       succeeded_list: "Here's who was synchronized:"
 
   time:

--- a/spec/features/user_exports_to_net_suite_spec.rb
+++ b/spec/features/user_exports_to_net_suite_spec.rb
@@ -56,7 +56,7 @@ feature "user exports to net suite" do
     expect(current_email).to have_text(
       t(
         "sync_mailer.sync_notification.succeeded",
-        employees: t("sync_mailer.sync_notification.employees", count: 2),
+        count: 2,
         integration: "NetSuite"
       )
     )
@@ -64,7 +64,7 @@ feature "user exports to net suite" do
     expect(current_email).to have_text(
       t(
         "sync_mailer.sync_notification.failed",
-        employees: t("sync_mailer.sync_notification.employees", count: 1),
+        count: 1,
         integration: "NetSuite"
       )
     )

--- a/spec/features/user_imports_jobvite_candidates_spec.rb
+++ b/spec/features/user_imports_jobvite_candidates_spec.rb
@@ -41,7 +41,7 @@ feature "User imports jobvite candidates" do
     expect(current_email).to have_text(
       t(
         "sync_mailer.sync_notification.succeeded",
-        employees: t("sync_mailer.sync_notification.employees", count: 6),
+        count: 6,
         integration: "Jobvite"
       )
     )
@@ -84,7 +84,7 @@ feature "User imports jobvite candidates" do
     expect(current_email).to have_text(
       t(
         "sync_mailer.sync_notification.failed",
-        employees: t("sync_mailer.sync_notification.employees", count: 6),
+        count: 6,
         integration: "Jobvite"
       )
     )

--- a/spec/models/sync_notifier_spec.rb
+++ b/spec/models/sync_notifier_spec.rb
@@ -12,9 +12,11 @@ describe SyncNotifier do
         with(integration_id).
         and_return(connection)
       results = double(:results)
-      mail = double(SyncMailer, deliver_now: true)
+      mail = double(SyncMailer, deliver_later: true)
+      sync_summary = double(:sync_summary)
       allow(SyncSummary).
-        to receive(:create_from_results!)
+        to receive(:create_from_results!).
+        and_return(sync_summary)
       allow(SyncMailer).
         to receive(:sync_notification).
         and_return(mail)
@@ -25,17 +27,16 @@ describe SyncNotifier do
         results: results,
       )
 
-      expect(SyncMailer).to have_received(:sync_notification).
-        with(
-          email: user.email,
-          integration_id: integration_id,
-          results: results
-        )
-      expect(mail).to have_received(:deliver_now)
       expect(SyncSummary).to have_received(:create_from_results!).with(
         connection: connection,
         results: results
       )
+      expect(SyncMailer).to have_received(:sync_notification).
+        with(
+          email: user.email,
+          sync_summary: sync_summary
+        )
+      expect(mail).to have_received(:deliver_later)
     end
   end
 end


### PR DESCRIPTION
Because:

* Failures were preventing the activity feed from updating
* We had duplicate logic for summarization sync results
* Failed emails will result in retrying the entire job

This commit:

* Records sync events before attempting to send emails
* Reuses the existing sync summary for email content
* Sends emails in separate background jobs