### PR TITLE
Display authorization errors in activity feed

### DIFF
--- a/app/assets/stylesheets/_errors.scss
+++ b/app/assets/stylesheets/_errors.scss
@@ -10,3 +10,11 @@
     color: $orange;
   }
 }
+
+.error {
+  h2 {
+    @extend .fa;
+    @extend .fa-exclamation-circle;
+    color: darken($error-color, 70);
+  }
+}

--- a/app/models/unauthorized_notifier.rb
+++ b/app/models/unauthorized_notifier.rb
@@ -8,12 +8,8 @@ class UnauthorizedNotifier
     @exception = exception
   end
 
-  def integration_name
-    I18n.t("#{integration_id}.name")
-  end
-
   def deliver
-    log_unauthorized_exception
+    record_sync_summary
     deliver_unauthorized_notification
   end
 
@@ -28,10 +24,10 @@ class UnauthorizedNotifier
     )
   end
 
-  def log_unauthorized_exception
-    Rails.logger.error(
-      "#{exception.class} error #{exception.message} for " \
-      "installation_id: #{installation.id} with #{integration_name}"
+  def record_sync_summary
+    SyncSummary.create!(
+      connection: connection,
+      authorization_error: exception.message
     )
   end
 

--- a/app/views/sync_summaries/_authorization_error.html.erb
+++ b/app/views/sync_summaries/_authorization_error.html.erb
@@ -1,0 +1,11 @@
+<div class="error">
+  <h2><%= t(".heading") %></h2>
+  <p><%= t(
+    ".error_html",
+    error: sync_summary.authorization_error,
+    link:  link_to(
+      t(".update_authorization"),
+      edit_integration_authentication_path(sync_summary.integration_id)
+    )
+  ) %></p>
+</div>

--- a/app/views/sync_summaries/_sync_summary.html.erb
+++ b/app/views/sync_summaries/_sync_summary.html.erb
@@ -7,11 +7,17 @@
         duration: time_ago_in_words(sync_summary.created_at)
       )
     ) %>
-    <%= render "sync_summaries/profile_events",
-      status: "success",
-      profile_events: sync_summary.profile_events.successful %>
-    <%= render "sync_summaries/profile_events",
-      status: "failure",
-      profile_events: sync_summary.profile_events.failed %>
+
+    <% if sync_summary.authorization_error? %>
+      <%= render "sync_summaries/authorization_error",
+        sync_summary: sync_summary %>
+    <% else %>
+      <%= render "sync_summaries/profile_events",
+        status: "success",
+        profile_events: sync_summary.profile_events.successful %>
+      <%= render "sync_summaries/profile_events",
+        status: "failure",
+        profile_events: sync_summary.profile_events.failed %>
+    <% end %>
   </div>
 </article>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,14 @@ en:
       slogan: >
         Below is a history of synchronization attempts with %{integration}.
 
+  sync_summaries:
+    authorization_error:
+      error_html: >
+        Unable to complete sync due to an authorization error.
+        The error returned was "%{error}". Please %{link} to correct this issue.
+      heading: Authorization Error
+      update_authorization: update the authorization information
+
   sync_summary:
     success_heading:
       one: "Successfully synced one profile:"

--- a/db/migrate/20150903161836_add_authorization_error_to_sync_summaries.rb
+++ b/db/migrate/20150903161836_add_authorization_error_to_sync_summaries.rb
@@ -1,0 +1,5 @@
+class AddAuthorizationErrorToSyncSummaries < ActiveRecord::Migration
+  def change
+    add_column(:sync_summaries, :authorization_error, :string)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150902145916) do
+ActiveRecord::Schema.define(version: 20150903161836) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,10 +131,11 @@ ActiveRecord::Schema.define(version: 20150902145916) do
   add_index "profile_events", ["sync_summary_id"], name: "index_profile_events_on_sync_summary_id", using: :btree
 
   create_table "sync_summaries", force: :cascade do |t|
-    t.integer  "connection_id",   null: false
-    t.string   "connection_type", null: false
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.integer  "connection_id",       null: false
+    t.string   "connection_type",     null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+    t.string   "authorization_error"
   end
 
   add_index "sync_summaries", ["connection_type", "connection_id"], name: "index_sync_summaries_on_connection_type_and_connection_id", using: :btree

--- a/spec/features/user_views_activity_feed_spec.rb
+++ b/spec/features/user_views_activity_feed_spec.rb
@@ -47,6 +47,22 @@ feature "User views activity feed" do
     expect(page).to have_text("Email is required")
   end
 
+  scenario "with authorization error" do
+    sync_summary = view_activity_feed do |connection|
+      create(
+        :sync_summary,
+        connection: connection,
+        authorization_error: "401 Unauthorized"
+      )
+    end
+
+    expect(page).to have_text(sync_summary.authorization_error)
+    click_link t("sync_summaries.authorization_error.update_authorization")
+    expect(current_path).to eq edit_integration_authentication_path(
+      sync_summary.integration_id
+    )
+  end
+
   def view_activity_feed
     user = create(:user)
     connection = create(
@@ -55,9 +71,9 @@ feature "User views activity feed" do
       installation: user.installation
     )
 
-    yield connection
-
-    visit dashboard_path(as: user)
-    find(".net-suite-account").click_link(t("dashboards.show.activity_feed"))
+    yield(connection).tap do
+      visit dashboard_path(as: user)
+      find(".net-suite-account").click_link(t("dashboards.show.activity_feed"))
+    end
   end
 end


### PR DESCRIPTION
Previously, the only user-facing notification of authorization errors
was in an email notification. Adding those events to the activity feed
makes it so there's a centralized place to see what's happening with
your integration.