### PR TITLE
Fix NetSuite employee creation

### DIFF
--- a/app/models/net_suite/export.rb
+++ b/app/models/net_suite/export.rb
@@ -62,7 +62,7 @@ module NetSuite
       end
 
       def id
-        @profile["netsuite_id"]
+        @profile["netsuite_id"].to_s
       end
 
       def attributes

--- a/spec/fixtures/api_responses/profiles_with_net_suite_fields.json
+++ b/spec/fixtures/api_responses/profiles_with_net_suite_fields.json
@@ -22,7 +22,8 @@
         "country_id":"US",
         "state_id":"MA",
         "zip": "02108"
-      }
+      },
+      "netsuite_id":""
     },
     {
       "id":"a759ba38-1522-443a-bdae-435d721eb316",
@@ -36,6 +37,7 @@
         "id":"7ac05eec-4b6a-4ec6-bd08-f1c1572815c6",
         "title":"COO"
       },
+      "netsuite_id":"",
       "custom_field":"secondary@example.com"
     },
     {


### PR DESCRIPTION
The Namely API actually return empty string rather than null for new
employees.

This has always been the case, but a recent refactoring changed it to
check for null (which we were using in our fixtures) rather than empty
string.

This changes the fixtures to be more realistic, so that we'll catch
future regressions, and fixes the NetSuite client to create a new
employee when it receives an empty string ID.