### PR TITLE
Handle more Errors from NetSuite

### DIFF
--- a/app/models/net_suite/api_error.rb
+++ b/app/models/net_suite/api_error.rb
@@ -1,15 +1,22 @@
 module NetSuite
-  # Wraps BadRequest errors from Cloud Elements. Attempts to parse a
+  # Wraps HTTP errors from Cloud Elements. Attempts to parse a
   # human-readable error message from the response.
   class ApiError < StandardError
-    def initialize(response)
-      @response = response
+    attr_reader :http_code
+
+    def initialize(exception)
+      @response = exception.response
+      @http_code = exception.http_code
     end
 
     def message
       response_data["providerMessage"] ||
         response_data["message"] ||
         "Unknown error"
+    end
+
+    def to_s
+      "NetSuite API Error: #{http_code} - #{message}"
     end
 
     private

--- a/app/models/net_suite/client/request.rb
+++ b/app/models/net_suite/client/request.rb
@@ -38,11 +38,13 @@ module NetSuite
         if response.present?
           JSON.parse(response)
         end
-      rescue RestClient::BadRequest => exception
-        Rails.logger.error "Bad Request: #{exception.response}"
-        raise NetSuite::ApiError, exception.response
       rescue RestClient::Unauthorized => exception
         raise Unauthorized, exception.message
+      rescue RestClient::Exception => exception
+        api_error = NetSuite::ApiError.new(exception)
+        Raygun.track_exception(api_error)
+        Rails.logger.error(api_error.to_s)
+        raise NetSuite::ApiError, exception
       end
 
       def url(path)

--- a/app/models/net_suite/export.rb
+++ b/app/models/net_suite/export.rb
@@ -80,7 +80,7 @@ module NetSuite
       rescue NetSuite::ApiError => exception
         Result.new(
           success: false,
-          error: exception.message,
+          error: exception.to_s,
           updated: updated,
           profile: @profile
         )

--- a/spec/models/net_suite/api_error_spec.rb
+++ b/spec/models/net_suite/api_error_spec.rb
@@ -5,7 +5,12 @@ describe NetSuite::ApiError do
     context "with a JSON message" do
       it "returns the encoded message" do
         message = "Error"
-        error = NetSuite::ApiError.new({ "providerMessage" => message }.to_json)
+        exception = double(
+          :exception,
+          response: { "providerMessage" => message }.to_json,
+          http_code: 499
+        )
+        error = NetSuite::ApiError.new(exception)
 
         result = error.message
 
@@ -16,7 +21,12 @@ describe NetSuite::ApiError do
     context "with a JSON provider message" do
       it "returns the encoded message" do
         message = "Error"
-        error = NetSuite::ApiError.new({ "message" => message }.to_json)
+        exception = double(
+          :exception,
+          response: { "message" => message }.to_json,
+          http_code: 499
+        )
+        error = NetSuite::ApiError.new(exception)
 
         result = error.message
 
@@ -26,7 +36,8 @@ describe NetSuite::ApiError do
 
     context "with JSON without a message" do
       it "returns a default message" do
-        error = NetSuite::ApiError.new({}.to_json)
+        exception = double(:exception, response: {}.to_json, http_code: 499)
+        error = NetSuite::ApiError.new(exception)
 
         result = error.message
 
@@ -36,7 +47,8 @@ describe NetSuite::ApiError do
 
     context "with an empty response" do
       it "returns a default message" do
-        error = NetSuite::ApiError.new(nil)
+        exception = double(:exception, response: nil, http_code: 499)
+        error = NetSuite::ApiError.new(exception)
 
         result = error.message
 

--- a/spec/models/net_suite/authentication_spec.rb
+++ b/spec/models/net_suite/authentication_spec.rb
@@ -48,8 +48,12 @@ describe NetSuite::Authentication do
 
     context "when the server form fails" do
       it "adds validation errors from the server" do
-        exception = NetSuite::ApiError.new({ "message" => "oops" }.to_json)
-        client = stub_client { raise exception }
+        exception = double(
+          :exception,
+          response: { "message" => "oops" }.to_json,
+          http_code: 499
+        )
+        client = stub_client { raise NetSuite::ApiError, exception }
         connection = stub_connection
         form = NetSuite::Authentication.new(
           connection: connection,

--- a/spec/models/net_suite/export_spec.rb
+++ b/spec/models/net_suite/export_spec.rb
@@ -65,17 +65,19 @@ describe NetSuite::Export do
 
     context "with an invalid employee" do
       it "returns a failure result" do
-        error = "invalid employee"
         profile = stub_profile
-        exception = NetSuite::ApiError.new(
-          { "message" => error }.to_json
+        exception = double(
+          :exception,
+          response: { "message" => "invalid employee" }.to_json,
+          http_code: 499
         )
-        net_suite = stub_net_suite { raise exception }
+        error = NetSuite::ApiError.new(exception)
+        net_suite = stub_net_suite { raise error }
 
         results = perform_export(net_suite: net_suite, profiles: [profile])
 
         expect(results.map(&:success?)).to eq([false])
-        expect(results.map(&:error)).to eq([error])
+        expect(results.map(&:error)).to eq([error.to_s])
         expect(profile).not_to have_received(:update)
       end
     end


### PR DESCRIPTION
We occasionally get errors back from NetSuite other than 400 (Bad
Request) or 401 (Unauthorized). When this happense, we're crashing the
entire job.

By handling `RestClient::Exception`, we can handle *all*  unexpected
HTTP response codes, allowing the job to continue running to completion
and record a proper `SyncSummary`.