### PR TITLE
Report DelayedJob exceptions to Raygun

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,3 @@
+require "delayed_raygun"
+
+Delayed::Worker.plugins << DelayedRaygun

--- a/lib/delayed_raygun.rb
+++ b/lib/delayed_raygun.rb
@@ -1,0 +1,13 @@
+class DelayedRaygun < Delayed::Plugin
+  callbacks do |lifecycle|
+    lifecycle.around(:invoke_job) do |job, *args, &block|
+      begin
+        block.call(job, *args)
+      rescue StandardError => error
+        Raygun.track_exception(error)
+        Rails.logger.error(error.message)
+        raise error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Raygun doesn't ship with support for DelayedJob out of the box, so we
have to use DelayedJob's plugin system to catch and report these. I
based this plugin off of this: http://blog.salsify.com/engineering/delayed-jobs-callbacks-and-hooks-in-rails

I could not conceive of a good way to test this in an automated fashion,
so I tested it in development by setting SyncJob to raise from `perform`
and making sure the `rescue` block in the plugin was executing and that
DelayedJob still requeued the job for a retry.