### PR TITLE
Limit DelayedJob retries

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,3 +1,4 @@
 require "delayed_raygun"
 
+Delayed::Worker.max_attempts = 4
 Delayed::Worker.plugins << DelayedRaygun


### PR DESCRIPTION
By default, DelayedJob will retry a job 25 times before failing. If it
goes that long, the last retry will be 20 days after the job was first
enqueued, after a 100 hour backoff interval, due to the exponential
backoff.

The jobs we run do not need to hang around that long. The NetSuite sync
job will be re-run daily anyway. Setting the max retries to 4 means that
the final backoff interval is just under 5 minutes. All told it would
take under 10 minutes for us to fail a job entirely.