### PR TITLE
Add background job to refresh Namely access tokens

### DIFF
--- a/app/jobs/token_refresh_job.rb
+++ b/app/jobs/token_refresh_job.rb
@@ -1,0 +1,5 @@
+class TokenRefreshJob < ActiveJob::Base
+  def perform(user)
+    user.fresh_access_token
+  end
+end

--- a/lib/tasks/namely.rake
+++ b/lib/tasks/namely.rake
@@ -1,0 +1,8 @@
+namespace :namely do
+  desc "Refresh access tokens for all users"
+  task refresh_access_tokens: :environment do
+    User.all.each do |user|
+      TokenRefreshJob.perform_later(user)
+    end
+  end
+end

--- a/spec/jobs/token_refresh_job_spec.rb
+++ b/spec/jobs/token_refresh_job_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe TokenRefreshJob do
+  it "updates the users refresh token" do
+    user = double(User)
+    allow(user).to receive :fresh_access_token
+
+    TokenRefreshJob.perform_now(user)
+
+    expect(user).to have_received :fresh_access_token
+  end
+end


### PR DESCRIPTION
We've seen situations where users that own an integration end up having
their access tokens go stale, which causes 401 errors. In order to
prevent users from having stale access tokens, we are creating a
background job to be run daily that refreshes all tokens.