### PR TITLE
Improve reporting of API errors

### DIFF
--- a/app/models/net_suite/client/request.rb
+++ b/app/models/net_suite/client/request.rb
@@ -41,10 +41,9 @@ module NetSuite
       rescue RestClient::Unauthorized => exception
         raise Unauthorized, exception.message
       rescue RestClient::Exception => exception
-        api_error = NetSuite::ApiError.new(exception)
-        Raygun.track_exception(api_error)
-        Rails.logger.error(api_error.to_s)
-        raise NetSuite::ApiError, exception
+        Raygun.track_exception(exception)
+        Rails.logger.error(exception)
+        raise NetSuite::ApiError, exception, exception.backtrace
       end
 
       def url(path)


### PR DESCRIPTION
Form a reporting perspective, we want to capture as much context from
the original exception as possible. By logging the original exception,
we'll easily be able to differentiate the different subclasses of
`RestClient::Exception` We are only raising a different exception in
order to isolate our application from the RestClient dependency.

Finally, when we create the NetSuite::ApiError, we want to be sure to
include the pre-existing backtrace so we can get good stacktraces
wherever this exception ends up peeking out again.