### PR TITLE
Allow failed profiles to be retried

### DIFF
--- a/app/assets/stylesheets/_activity-feed.scss
+++ b/app/assets/stylesheets/_activity-feed.scss
@@ -22,4 +22,13 @@
     color: $grey-75;
     font-weight: bold;
   }
+
+  .button_to {
+    float: right;
+  }
+
+  input {
+    @extend .-n-btn;
+    @extend .-n-btn-sm;
+  }
 }

--- a/app/controllers/retries_controller.rb
+++ b/app/controllers/retries_controller.rb
@@ -1,0 +1,21 @@
+class RetriesController < ApplicationController
+  def create
+    sync_summary = find_sync_summary
+    RetryJob.perform_later(sync_summary)
+
+    redirect_to sync_summary_retry_path(sync_summary: sync_summary)
+  end
+
+  def show
+  end
+
+  private
+
+  def find_sync_summary
+    SyncSummary.find(params[:sync_summary_id]).tap do |summary|
+      unless summary.users.include?(current_user)
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end

--- a/app/jobs/retry_job.rb
+++ b/app/jobs/retry_job.rb
@@ -1,0 +1,7 @@
+class RetryJob < ActiveJob::Base
+  def perform(sync_summary)
+    Notifier.execute(sync_summary.connection) do
+      sync_summary.retry
+    end
+  end
+end

--- a/app/jobs/sync_job.rb
+++ b/app/jobs/sync_job.rb
@@ -1,25 +1,7 @@
 class SyncJob < ActiveJob::Base
   def perform(connection)
-    results = connection.sync
-    deliver_sync_notification(connection, results)
-  rescue Unauthorized => exception
-    deliver_unauthorized_notification(connection, exception)
-  end
-
-  private
-
-  def deliver_sync_notification(connection, results)
-    SyncNotifier.deliver(
-      results: results,
-      installation: connection.installation,
-      integration_id: connection.integration_id
-    )
-  end
-
-  def deliver_unauthorized_notification(connection, exception)
-    UnauthorizedNotifier.deliver(
-      connection: connection,
-      exception: exception
-    )
+    Notifier.execute(connection) do
+      connection.sync
+    end
   end
 end

--- a/app/models/jobvite/connection.rb
+++ b/app/models/jobvite/connection.rb
@@ -87,6 +87,10 @@ module Jobvite
       delegate :name, to: :candidate
       delegate :success?, :error, to: :result
 
+      def profile_id
+        ""
+      end
+
       private
 
       attr_reader :candidate, :result

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -55,11 +55,11 @@ class NetSuite::Connection < ActiveRecord::Base
   end
 
   def sync
-    NetSuite::Export.new(
-      normalizer: normalizer,
-      namely_profiles: installation.namely_profiles,
-      net_suite: client
-    ).perform
+    perform_export(installation.namely_profiles)
+  end
+
+  def retry(sync_summary)
+    perform_export(sync_summary.failed_profiles)
   end
 
   def client
@@ -67,6 +67,14 @@ class NetSuite::Connection < ActiveRecord::Base
   end
 
   private
+
+  def perform_export(profiles)
+    NetSuite::Export.perform(
+      normalizer: normalizer,
+      namely_profiles: profiles,
+      net_suite: client
+    )
+  end
 
   def subsidiary_optional?
     if subsidiary_required.nil?

--- a/app/models/net_suite/export.rb
+++ b/app/models/net_suite/export.rb
@@ -1,5 +1,9 @@
 module NetSuite
   class Export
+    def self.perform(**args)
+      new(args).perform
+    end
+
     def initialize(normalizer:, namely_profiles:, net_suite:)
       @normalizer = normalizer
       @namely_profiles = namely_profiles
@@ -97,6 +101,10 @@ module NetSuite
 
       attr_reader :error
       delegate :email, :name, to: :profile
+
+      def profile_id
+        @profile.id
+      end
 
       def success?
         @success == true

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -6,6 +6,10 @@ class Profile
     @fields = fields
   end
 
+  def id
+    @namely_profile[:id]
+  end
+
   def name
     "#{namely_profile[:first_name]} #{namely_profile[:last_name]}"
   end

--- a/app/models/profile_event.rb
+++ b/app/models/profile_event.rb
@@ -4,7 +4,11 @@ class ProfileEvent < ActiveRecord::Base
   # Intended to be called via the association from a SyncSummary which will
   # provide the required `sync_summary_id` attribute.
   def self.create_from_result!(result)
-    create!(profile_name: result.name, error: result.error)
+    create!(
+      profile_id: result.profile_id,
+      profile_name: result.name,
+      error: result.error
+    )
   end
 
   def self.ordered

--- a/app/services/notifier.rb
+++ b/app/services/notifier.rb
@@ -1,0 +1,36 @@
+class Notifier
+  def self.execute(connection, &block)
+    new(connection).execute(&block)
+  end
+
+  def initialize(connection)
+    @connection = connection
+  end
+
+  def execute
+    yield.tap do |results|
+      deliver_sync_notification(results)
+    end
+  rescue Unauthorized => exception
+    deliver_unauthorized_notification(exception)
+  end
+
+  private
+
+  attr_reader :connection
+
+  def deliver_sync_notification(results)
+    SyncNotifier.deliver(
+      results: results,
+      installation: connection.installation,
+      integration_id: connection.integration_id
+    )
+  end
+
+  def deliver_unauthorized_notification(exception)
+    UnauthorizedNotifier.deliver(
+      connection: connection,
+      exception: exception
+    )
+  end
+end

--- a/app/views/retries/show.html.erb
+++ b/app/views/retries/show.html.erb
@@ -1,0 +1,4 @@
+<section id="subheader">
+  <h1><%= t(".title") %></h2>
+  <p><%= t(".slogan") %></p>
+</section>

--- a/app/views/sync_summaries/_profile_events.html.erb
+++ b/app/views/sync_summaries/_profile_events.html.erb
@@ -1,5 +1,10 @@
 <% if profile_events.any? %>
   <div class="<%= status %>">
+    <% if profile_events.failed.any? %>
+      <%= button_to t("profile_event.retry"),
+        sync_summary_retry_path(sync_summary),
+        method: :post %>
+    <% end %>
     <h2>
       <%= t "sync_summary.#{status}_heading", count: profile_events.size %>
     </h2>

--- a/app/views/sync_summaries/_sync_summary.html.erb
+++ b/app/views/sync_summaries/_sync_summary.html.erb
@@ -14,10 +14,12 @@
     <% else %>
       <%= render "sync_summaries/profile_events",
         status: "success",
-        profile_events: sync_summary.successful_profile_events %>
+        profile_events: sync_summary.successful_profile_events,
+        sync_summary: sync_summary %>
       <%= render "sync_summaries/profile_events",
         status: "failure",
-        profile_events: sync_summary.failed_profile_events %>
+        profile_events: sync_summary.failed_profile_events,
+        sync_summary: sync_summary %>
     <% end %>
   </div>
 </article>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,9 @@ en:
       other: "Unable to sync %{count} profiles:"
     time: "%{duration} ago"
 
+  profile_event:
+    retry: "Retry"
+
   candidate_import_mailer:
     successful_import:
       message: |
@@ -192,6 +195,13 @@ en:
       title: "Connect to %{integration}"
       slogan: >
         Please fill out the following fields to finalize this connection.
+
+  retries:
+    show:
+      title: Retrying Failed Profiles
+      slogan: >
+        We are synchronizing the failed profiles and will send you an email as
+        soon as synchronization is complete.
   syncs:
     create:
       title: "Synchronizing with %{integration}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,10 @@ Rails.application.routes.draw do
     resource :mapping, only: [:edit, :update]
   end
 
+  resources :sync_summaries, only: [] do
+    resource :retry, only: [:create, :show]
+  end
+
   get(
     "/session/oauth_callback",
     to: "sessions#oauth_callback",

--- a/db/migrate/20150903174313_add_profile_id_to_profile_events.rb
+++ b/db/migrate/20150903174313_add_profile_id_to_profile_events.rb
@@ -1,0 +1,10 @@
+class AddProfileIdToProfileEvents < ActiveRecord::Migration
+  def up
+    add_column :profile_events, :profile_id, :string
+    change_column_null :profile_events, :profile_id, false, ""
+  end
+
+  def down
+    remove_column :profile_events, :profile_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150903161836) do
+ActiveRecord::Schema.define(version: 20150903174313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 20150903161836) do
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
     t.string   "error"
+    t.string   "profile_id",      null: false
   end
 
   add_index "profile_events", ["error"], name: "index_profile_events_on_error", where: "(error IS NULL)", using: :btree

--- a/spec/controllers/retries_controller_spec.rb
+++ b/spec/controllers/retries_controller_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe RetriesController do
+  describe "#create" do
+    it "prevents users from retrying summaries they don't own" do
+      session[:current_user_id] = create(:user).id
+      summary = create(:sync_summary)
+      summary.installation.users << create(
+        :user,
+        installation: summary.installation
+      )
+
+      expect { post :create, sync_summary_id: summary.id }.
+        to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -103,6 +103,7 @@ FactoryGirl.define do
 
   factory :profile_event do
     sync_summary
+    sequence(:profile_id) { |n| "namely-#{n}-id" }
     profile_name "Example Name"
   end
 end

--- a/spec/features/user_retries_failed_profile_sync_spec.rb
+++ b/spec/features/user_retries_failed_profile_sync_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+feature "User retries failed profile sync" do
+  scenario "sees result in activity feed" do
+    user = create(:user)
+    connection = create_connection_for(user)
+    create_failed_profile_event_for(connection)
+    stub_namely_data("/profiles", "profiles_with_net_suite_fields")
+    stub_namely_fields("fields_with_net_suite")
+    stub_retry_of_failed_profile_event
+
+    visit_activity_feed(connection, user)
+    click_on t("profile_event.retry")
+    visit_activity_feed(connection, user)
+
+    expect(page).to have_text("Successfully synced one profile")
+  end
+
+  def create_connection_for(user)
+    mapping = create(:field_mapping)
+    create(
+      :net_suite_connection,
+      :ready,
+      attribute_mapper: mapping.attribute_mapper,
+      installation: user.installation
+    )
+  end
+
+  def create_failed_profile_event_for(connection)
+    sync_summary = create(:sync_summary, connection: connection)
+    create(
+      :profile_event,
+      sync_summary: sync_summary,
+      profile_name: "Tina Tech",
+      profile_id: "3f51b510-1922-11e5-b939-0800200c9a66",
+      error: "Phone number is invalid"
+    )
+  end
+
+  def stub_retry_of_failed_profile_event
+    stub_request(
+      :patch,
+      "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees/1234"
+    ).with(body: hash_including(firstName: "Tina")).to_return(status: 200)
+  end
+
+  def visit_activity_feed(connection, user)
+    visit integration_activity_feed_path(
+      integration_id: connection.integration_id,
+      as: user
+    )
+  end
+end

--- a/spec/jobs/retry_job_spec.rb
+++ b/spec/jobs/retry_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe RetryJob do
+  it "runs a retry" do
+    sync_summary = create(:sync_summary)
+    allow(sync_summary).to receive(:retry).and_return([])
+
+    RetryJob.perform_now(sync_summary)
+
+    expect(sync_summary).to have_received(:retry)
+  end
+
+  it "notifies of results" do
+    sync_summary = create(:sync_summary)
+    allow(Notifier).to receive(:execute)
+
+    RetryJob.perform_now(sync_summary)
+
+    expect(Notifier).to have_received(:execute).with(sync_summary.connection)
+  end
+end

--- a/spec/models/net_suite/export_spec.rb
+++ b/spec/models/net_suite/export_spec.rb
@@ -6,15 +6,20 @@ describe NetSuite::Export do
       it "returns a result with created profiles" do
         profile_data = [
           {
+            id: "abc123",
+            email: "one@example.com",
             first_name: "One",
             last_name: "Last"
           },
           {
+            id: "def456",
+            email: "two@example.com",
             first_name: "Two",
             last_name: "Last"
           }
         ]
         profiles = profile_data.map { |profile| stub_profile(profile) }
+        ids = profile_data.map { |profile| profile[:id] }
         names = profile_data.map do |profile|
           "#{profile[:first_name]} #{profile[:last_name]}"
         end
@@ -32,6 +37,7 @@ describe NetSuite::Export do
         expect(results.map(&:success?)).to eq([true, true])
         expect(results.map(&:updated?)).to eq([false, false])
         expect(results.map(&:name)).to eq(names)
+        expect(results.map(&:profile_id)).to eq(ids)
         expect(net_suite).to have_received(:create_employee).
           with(mapped_attributes).
           exactly(2)
@@ -100,7 +106,7 @@ describe NetSuite::Export do
         netsuite_id: ""
       }.merge(overrides)
 
-      stub_attributes(profile, attributes.merge(overrides))
+      stub_attributes(profile, attributes)
       allow(profile).to receive(:update)
       allow(profile).to receive(:name).and_return(
         "#{attributes[:first_name]} #{attributes[:last_name]}"
@@ -115,6 +121,8 @@ describe NetSuite::Export do
         with(name.to_s).
         and_return(Fields::StringValue.new(value))
     end
+
+    allow(profile).to receive(:id).and_return(attributes[:id])
   end
 
   def stub_net_suite(&block)

--- a/spec/models/profile_event_spec.rb
+++ b/spec/models/profile_event_spec.rb
@@ -17,24 +17,37 @@ describe ProfileEvent do
     context "with a successful result" do
       it "creates a successful profile event" do
         sync_summary = create(:sync_summary)
-        result = double(:result, name: "Name", error: nil)
+        result = double(
+          :result,
+          name: "Name",
+          error: nil,
+          profile_id: "abc123"
+        )
 
         profile_event = sync_summary.profile_events.create_from_result!(result)
 
         expect(profile_event).to be_persisted
         expect(profile_event).to be_successful
+        expect(profile_event.profile_name).to eq("Name")
+        expect(profile_event.profile_id).to eq("abc123")
       end
     end
 
     context "with an unsuccessful result" do
       it "creates an unsuccessful profile event" do
         sync_summary = create(:sync_summary)
-        result = double(:result, name: "Name", error: "Failure")
+        result = double(
+          :result,
+          name: "Name",
+          error: "Failure",
+          profile_id: "abc123"
+        )
 
         profile_event = sync_summary.profile_events.create_from_result!(result)
 
         expect(profile_event).to be_persisted
         expect(profile_event).not_to be_successful
+        expect(profile_event.profile_id).to eq("abc123")
       end
     end
   end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -23,6 +23,18 @@ describe Profile do
     end
   end
 
+  describe "#id" do
+    it "returns the raw ID" do
+      profile_data = { id: "uvx" }
+      fields = double(:fields)
+      profile = Profile.new(profile_data, fields: fields)
+
+      result = profile.id
+
+      expect(result).to eq("uvx")
+    end
+  end
+
   describe "#name" do
     it "returns #first_name #last_name" do
       profile_data = {

--- a/spec/models/sync_summary_spec.rb
+++ b/spec/models/sync_summary_spec.rb
@@ -4,7 +4,7 @@ describe SyncSummary do
   describe ".create_from_results" do
     it "creates a sync summary for the connection with the given results" do
       names = %w(Billy Wendy Franko)
-      results = names.map { |name| double(:result, name: name, error: nil) }
+      results = names.map { |name| stub_profile(name: name) }
       connection = create(:net_suite_connection)
 
       summary = SyncSummary.create_from_results!(
@@ -24,5 +24,40 @@ describe SyncSummary do
 
       expect(SyncSummary.ordered).to eq [newest, oldest]
     end
+  end
+
+  describe "#failed_profiles" do
+    it "returns profiles corresponding to the failed profile events" do
+      failed_event = create(
+        :profile_event,
+        error: "Something went wrong",
+        profile_id: "abc-def",
+        profile_name: "Derek",
+      )
+      sync_summary = failed_event.sync_summary
+      failed_profile = double("Failed Profile", id: failed_event.profile_id)
+      allow(sync_summary.installation).to receive(:namely_profiles).and_return([
+        double("Profile", id: "xxx-zzz"),
+        failed_profile
+      ])
+
+      expect(sync_summary.failed_profiles).to eq [failed_profile]
+    end
+  end
+
+  describe "#retry" do
+    it "uses the connection to retry profiles from the sync summary" do
+      sync_summary = create(:sync_summary)
+      allow(sync_summary.connection).to receive(:retry)
+
+      sync_summary.retry
+
+      expect(sync_summary.connection).to have_received(:retry).
+        with(sync_summary)
+    end
+  end
+
+  def stub_profile(name:)
+    double(:result, profile_id: "x", name: name, error: nil)
   end
 end

--- a/spec/services/notifier_spec.rb
+++ b/spec/services/notifier_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe Notifier do
+  it "runs the provided block and emails the results" do
+    connection = build_stubbed(:net_suite_connection)
+    results = double(:results)
+    allow(connection).to receive(:sync).and_return(results)
+    allow(SyncNotifier).to receive(:deliver)
+
+    Notifier.execute(connection) do
+      connection.sync
+    end
+
+    expect(connection).to have_received(:sync)
+    expect(SyncNotifier).
+      to have_received(:deliver).
+      with(
+        results: results,
+        integration_id: connection.integration_id,
+        installation: connection.installation
+      )
+  end
+
+  context "authentication failure" do
+    it "traps exception and alerts the user" do
+      connection = build_stubbed(:net_suite_connection)
+      exception = Unauthorized.new("An error message")
+      allow(connection).to receive(:sync).and_raise(exception)
+      allow(UnauthorizedNotifier).to receive(:deliver)
+
+      Notifier.execute(connection) do
+        connection.sync
+      end
+
+      expect(UnauthorizedNotifier).to have_received(:deliver).
+        with(connection: connection, exception: exception)
+    end
+  end
+end


### PR DESCRIPTION
An installation may have hundreds or even thousands of namely profiles
with only a small number of failures. In these cases, it's reasonable
for users to want to quickly retry only the failed profiles once they
think they have made sufficient corrections.

To facilitate, this change introduces a `RetryJob` which will sync only
the failed profiles associated with a sync summary. Syncing was built to
sync all namely profiles over a given connection, so we needed a way to
tell the sync operation to only sync a subset of profiles. An optional
named argument of `profiles` was added to the net suite sync.

A `Sync` class was also extracted to handle the common concern of
notifications between the `SyncJob` and `RetryJob`. This class will pass
on any keyword arguments it receives to the sync operation. To avoid
having to do a conditional on the presence of keyword arguments, the
Jobvite `sync` definition had to be updated to accept keyword arguments
because it will be passed an empty hash of them.