### PR TITLE
Include custom fields on greenhouse imports

### DIFF
--- a/spec/fixtures/api_requests/greenhouse_payload_job_custom_fields.json
+++ b/spec/fixtures/api_requests/greenhouse_payload_job_custom_fields.json
@@ -58,12 +58,8 @@
             "name": "Desired Level",
             "type": "short_text",
             "value": "Senior"
-          },
-          "favorite_programming_language": {
-            "name": "Favorite Programming Language",
-            "type": "short_text",
-            "value": "Rails"
-          }}
+          }
+        }
       },
       "job": {
         "id": 20,

--- a/spec/fixtures/api_requests/greenhouse_payload_missing.json
+++ b/spec/fixtures/api_requests/greenhouse_payload_missing.json
@@ -18,7 +18,7 @@
         "last_name": "Smith",
         "title": "Previous Title",
         "phone_numbers": [
-          { 
+          {
             "value": "518-555-1212",
             "type": "work"
           },
@@ -28,7 +28,7 @@
           }
         ],
         "email_addresses": [
-          { 
+          {
             "value": "personal@example.com",
             "type": "personal"
           },
@@ -52,12 +52,8 @@
             "name": "Desired Level",
             "type": "short_text",
             "value": "Senior"
-          },
-          "favorite_programming_language": {
-            "name": "Favorite Programming Language",
-            "type": "short_text",
-            "value": "Rails"
-          }}
+          }
+        }
       },
       "job": {
         "id": 20,

--- a/spec/fixtures/api_requests/greenhouse_payload_offer_custom_fields.json
+++ b/spec/fixtures/api_requests/greenhouse_payload_offer_custom_fields.json
@@ -58,12 +58,8 @@
             "name": "Desired Level",
             "type": "short_text",
             "value": "Senior"
-          },
-          "favorite_programming_language": {
-            "name": "Favorite Programming Language",
-            "type": "short_text",
-            "value": "Rails"
-          }}
+          }
+        }
       },
       "job": {
         "id": 20,

--- a/spec/fixtures/api_requests/greenhouse_payload_salary_text.json
+++ b/spec/fixtures/api_requests/greenhouse_payload_salary_text.json
@@ -58,12 +58,8 @@
             "name": "Desired Level",
             "type": "short_text",
             "value": "Senior"
-          },
-          "favorite_programming_language": {
-            "name": "Favorite Programming Language",
-            "type": "short_text",
-            "value": "Rails"
-          }}
+          }
+        }
       },
       "job": {
         "id": 20,

--- a/spec/fixtures/api_responses/fields_with_greenhouse.json
+++ b/spec/fixtures/api_responses/fields_with_greenhouse.json
@@ -34,6 +34,17 @@
       }
     },
     {
+      "id": "290c8179-82bf-494b-8d40-0dca23cfbfff",
+      "name": "favorite_programming_language",
+      "label": "Favorite Programming Language",
+      "type": "text",
+      "default": true,
+      "valid_format_info": "generic text",
+      "links": {
+        "section": "8433dc38-2f72-4cd6-997a-665d6c62fb79"
+      }
+    },
+    {
       "id": "0483a39f-5dd0-4080-a34a-b00f1a1b62fd",
       "name": "last_name",
       "label": "Last name",

--- a/spec/models/greenhouse/normalizer_spec.rb
+++ b/spec/models/greenhouse/normalizer_spec.rb
@@ -26,6 +26,7 @@ describe Greenhouse::Normalizer do
           currency_type: "USD",
           date: "2015-01-23"
         },
+        favorite_programming_language: "Rails"
       )
     end
 


### PR DESCRIPTION
Custom fields are supported in Greenhouse imports so long as there is an
identically named namely field of the proper type. Unfortunately, when
Greenhouse was moved to the attribute mapper, we stopped syncing these
custom fields.

The custom fields didn't have attribute mappings (and can't, because we
have no way to get a list of fields from Greenhouse until they send us a
user), so the attribute mapper was dropping them. To fix this, we have
the normalizer specifically whitelist any of the matching custom fields.