### PR TITLE
Add response body to unauthorized exception for helpful logging.

### DIFF
--- a/app/models/icims/authorized_request.rb
+++ b/app/models/icims/authorized_request.rb
@@ -67,7 +67,7 @@ module Icims
       Rails.logger.info("ICIMS request END")
       r.execute
     rescue RestClient::Unauthorized => exception
-      unauthorized_exception = Unauthorized.new(exception.message)
+      unauthorized_exception = Unauthorized.new(generate_message(exception))
       UnauthorizedNotifier.deliver(
         connection: connection,
         exception: unauthorized_exception
@@ -115,6 +115,10 @@ module Icims
 
     def hashed_payload
       digest.hexdigest(payload)
+    end
+
+    def generate_message(exception)
+      [ exception.message, exception.response.body ].join("\n\n")
     end
   end
 end


### PR DESCRIPTION
Right now we're getting 401 error messages sent to customers but the response body from ICIMS includes much more detail that can help. For example:

```json
{
  "errors": [
    {
      "errorMessage": "Request Expired : Time difference exceeds 300 seconds threshold.",
      "errorCode": 40
    }
  ]
}
```