### PR TITLE
Add body content to Unauthed requests to make greenhouse backoff.

### DIFF
--- a/app/controllers/greenhouse_candidate_imports_controller.rb
+++ b/app/controllers/greenhouse_candidate_imports_controller.rb
@@ -15,7 +15,7 @@ class GreenhouseCandidateImportsController < ApplicationController
 
     render json: { status: "ok" }, status: :ok
   rescue Unauthorized
-    render nothing: true, status: :accepted
+    render json: { status: "accepted" }, status: :accepted
   end
 
   private


### PR DESCRIPTION
Similar to #225 this (in theory) will prevent greenhouse from pegging us with multiple requests.