### PR TITLE
Extra Netsuite parameters for SSO mapping

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -8,6 +8,8 @@ HOST="http://localhost:7000"
 # Set these from your Cloud Elements console
 CLOUD_ELEMENTS_ORGANIZATION_SECRET=secret
 CLOUD_ELEMENTS_USER_SECRET=secret
+NETSUITE_PARTNER_ID=partnerid
+NETSUITE_APP_ID=appid
 
 # Set these variables when rebuilding VCR fixtures:
 TEST_JOBVITE_KEY=...

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "pry-rails"
   gem "rspec-rails", "~> 3.3"
+  gem 'binding_of_caller', '~> 0.7.2'
+  gem 'better_errors', '~> 2.1.1'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,12 @@ GEM
     arel (6.0.3)
     awesome_print (1.6.1)
     backports (3.6.5)
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     bourbon (3.2.4)
       sass (~> 3.2)
       thor
@@ -81,6 +87,7 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.4.1)
+    debug_inspector (0.0.2)
     delayed_job (4.0.6)
       activesupport (>= 3.0, < 5.0)
     delayed_job_active_record (4.0.3)
@@ -292,6 +299,8 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
+  better_errors (~> 2.1.1)
+  binding_of_caller (~> 0.7.2)
   bourbon (~> 3.2.1)
   byebug
   capybara-email

--- a/app/models/installation.rb
+++ b/app/models/installation.rb
@@ -57,8 +57,6 @@ class Installation < ActiveRecord::Base
     owner.namely_profiles
   end
 
-  private
-
   def owner
     users.first
   end

--- a/app/models/installation.rb
+++ b/app/models/installation.rb
@@ -57,6 +57,10 @@ class Installation < ActiveRecord::Base
     owner.namely_profiles
   end
 
+  def namely_user_id
+    owner.namely_user_id
+  end
+
   def owner
     users.first
   end

--- a/app/models/net_suite/authentication.rb
+++ b/app/models/net_suite/authentication.rb
@@ -1,6 +1,7 @@
 module NetSuite
   class Authentication
     include ActiveModel::Model
+    extend Forwardable
 
     attr_accessor :account_id, :email, :password
 
@@ -20,6 +21,22 @@ module NetSuite
     def update(attributes)
       self.attributes = attributes
       valid? && create_instance
+    end
+
+    def user_id
+      @connection.installation.owner.namely_user_id
+    end
+
+    def company_id
+      @connection.installation.subdomain
+    end
+
+    def app_id
+      @client.app_id
+    end
+
+    def partner_id
+      @client.partner_id
     end
 
     private

--- a/app/models/net_suite/authentication.rb
+++ b/app/models/net_suite/authentication.rb
@@ -11,6 +11,7 @@ module NetSuite
 
     def initialize(connection:, client:)
       @connection = connection
+      @installation = connection.installation
       @client = client
     end
 
@@ -24,11 +25,11 @@ module NetSuite
     end
 
     def user_id
-      @connection.installation.owner.namely_user_id
+      @installation.namely_user_id
     end
 
     def company_id
-      @connection.installation.subdomain
+      @installation.subdomain
     end
 
     def app_id

--- a/app/models/net_suite/client.rb
+++ b/app/models/net_suite/client.rb
@@ -7,28 +7,37 @@ module NetSuite
 
     delegate :get_json, to: :request
     delegate :submit_json, to: :request
+    attr_reader :partner_id, :app_id
 
     def self.from_env
       new(
         user_secret: ENV["CLOUD_ELEMENTS_USER_SECRET"],
-        organization_secret: ENV["CLOUD_ELEMENTS_ORGANIZATION_SECRET"]
+        organization_secret: ENV["CLOUD_ELEMENTS_ORGANIZATION_SECRET"],
+        partner_id: ENV["NETSUITE_PARTNER_ID"],
+        app_id: ENV["NETSUITE_APP_ID"]
       )
     end
 
     def initialize(
       user_secret:,
       organization_secret:,
+      partner_id:,
+      app_id:,
       element_secret: nil
     )
       @user_secret = user_secret
       @organization_secret = organization_secret
       @element_secret = element_secret
+      @partner_id = partner_id
+      @app_id = app_id
     end
 
     def authorize(element_secret)
       self.class.new(
         user_secret: @user_secret,
         organization_secret: @organization_secret,
+        partner_id: @partner_id,
+        app_id: @app_id,
         element_secret: element_secret
       )
     end
@@ -37,7 +46,7 @@ module NetSuite
       submit_json(
         :post,
         INSTANCES,
-        Instance.new(authentication).to_h
+        Instance.new(authentication: authentication).to_h
       )
     end
 

--- a/app/models/net_suite/instance.rb
+++ b/app/models/net_suite/instance.rb
@@ -1,6 +1,6 @@
 module NetSuite
   class Instance
-    def initialize(authentication)
+    def initialize(authentication:)
       @authentication = authentication
     end
 
@@ -10,7 +10,12 @@ module NetSuite
           "user.username" => authentication.email,
           "user.password" => authentication.password,
           "netsuite.accountId" => authentication.account_id,
-          "netsuite.sandbox" => false
+          "netsuite.sandbox" => false,
+          "netsuite.sso.roleId" => "3",
+          "netsuite.appId" => authentication.app_id,
+          "netsuite.sso.companyId" => authentication.company_id,
+          "netsuite.sso.userId" => authentication.user_id,
+          "netsuite.sso.partnerId" => authentication.partner_id,
         },
         "element" => {
           "key" => "netsuiteerp"

--- a/app/views/net_suite_connections/_authentication_form.html.erb
+++ b/app/views/net_suite_connections/_authentication_form.html.erb
@@ -7,3 +7,4 @@
 <div class="form-row">
   <%= form.input :password, input_html: {class: 'half'} %>
 </div>
+<p><%= t(".help") %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,4 +39,6 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
 
   config.action_mailer.default_url_options = { host: 'localhost:9000' }
+
+  BetterErrors::Middleware.allow_ip! ENV['TRUSTED_IP'] if ENV['TRUSTED_IP']
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,10 @@ en:
     description:
       connected_html: Connected NetSuite Description
       disconnected_html: Disconnected NetSuite Description
+    authentication_form:
+      help: >
+        Please note that the credentials are needed for initial connection to
+        NetSuite and will not be stored in Namely Connect.
 
   authentications:
     new:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,7 +181,7 @@ en:
       disconnected_html: Disconnected NetSuite Description
     authentication_form:
       help: >
-        Please note that the credentials are needed for initial connection to
+        Please note that these credentials are needed for initial connection to
         NetSuite and will not be stored in Namely Connect.
 
   authentications:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,11 @@ web:
   volumes:
    - .:/connect
   ports:
-   - "3000:3000"
+   - "80:3000"
+  env_file:
+    - .env
+  environment:
+    WEB_CONCURRENCY: 1
   links:
    - db
 worker:
@@ -16,5 +20,7 @@ worker:
   command: bundle exec rake jobs:work
   volumes:
    - .:/connect
+  env_file:
+    - .env
   links:
    - db

--- a/spec/models/installation_spec.rb
+++ b/spec/models/installation_spec.rb
@@ -145,6 +145,17 @@ describe Installation do
     end
   end
 
+  describe "#owner" do
+    it "returns its first user" do
+      users = [build_stubbed(:user), build_stubbed(:user)]
+      installation = Installation.new(users: users)
+
+      result = installation.owner
+
+      expect(result).to eq(users.first)
+    end
+  end
+
   def stub_each(array, method_name)
     array.each do |item|
       allow(item).to receive(method_name)

--- a/spec/models/net_suite/authentication_spec.rb
+++ b/spec/models/net_suite/authentication_spec.rb
@@ -77,6 +77,7 @@ describe NetSuite::Authentication do
   def stub_connection
     double(NetSuite::Connection).tap do |connection|
       allow(connection).to receive(:update!)
+      allow(connection).to receive(:installation)
     end
   end
 

--- a/spec/models/net_suite/client_spec.rb
+++ b/spec/models/net_suite/client_spec.rb
@@ -5,7 +5,9 @@ describe NetSuite::Client do
     it "finds authorization from the environment" do
       env = {
         "CLOUD_ELEMENTS_USER_SECRET" => "user-secret",
-        "CLOUD_ELEMENTS_ORGANIZATION_SECRET" => "org-secret"
+        "CLOUD_ELEMENTS_ORGANIZATION_SECRET" => "org-secret",
+        "NETSUITE_PARTNER_ID" => "partnerid",
+        "NETSUITE_APP_ID" => "appid"
       }
 
       ClimateControl.modify env do
@@ -31,6 +33,8 @@ describe NetSuite::Client do
       client = NetSuite::Client.new(
         user_secret: "user-secret",
         organization_secret: "org-secret",
+        partner_id: "partnerid",
+        app_id: "appid",
       )
 
       client.
@@ -54,7 +58,7 @@ describe NetSuite::Client do
         instance_request = { configuration: "foo", elements: "bar" }
         instance_response = { "id" => "123", "token" => "abcxyz" }
         allow(NetSuite::Instance).to receive(:new).
-          with(authentication).
+          with(authentication: authentication).
           and_return(instance_request)
 
         stub_request(
@@ -72,7 +76,9 @@ describe NetSuite::Client do
 
         client = NetSuite::Client.new(
           user_secret: "user-secret",
-          organization_secret: "org-secret"
+          organization_secret: "org-secret",
+          partner_id: "partnerid",
+          app_id: "appid",
         )
 
         result = client.create_instance(authentication)
@@ -94,7 +100,9 @@ describe NetSuite::Client do
 
         client = NetSuite::Client.new(
           user_secret: "x",
-          organization_secret: "x"
+          organization_secret: "x",
+          partner_id: "partnerid",
+          app_id: "appid",
         )
 
         expect { client.create_instance(double("Authentication")) }.
@@ -116,7 +124,9 @@ describe NetSuite::Client do
 
         client = NetSuite::Client.new(
           user_secret: "x",
-          organization_secret: "x"
+          organization_secret: "x",
+          partner_id: "partnerid",
+          app_id: "appid",
         )
 
         expect { client.create_instance(double("Authentication")) }.
@@ -155,6 +165,8 @@ describe NetSuite::Client do
         client = NetSuite::Client.new(
           user_secret: "user-secret",
           organization_secret: "org-secret",
+          partner_id: "partnerid",
+          app_id: "appid",
           element_secret: "element-secret"
         )
 
@@ -204,6 +216,8 @@ describe NetSuite::Client do
         client = NetSuite::Client.new(
           user_secret: "user-secret",
           organization_secret: "org-secret",
+          partner_id: "partnerid",
+          app_id: "appid",
           element_secret: "element-secret"
         )
 
@@ -276,6 +290,8 @@ describe NetSuite::Client do
     NetSuite::Client.new(
       user_secret: "user-secret",
       organization_secret: "org-secret",
+      partner_id: "partnerid",
+      app_id: "appid",
       element_secret: "element-secret"
     )
   end

--- a/spec/models/net_suite/employee_fields_loader_spec.rb
+++ b/spec/models/net_suite/employee_fields_loader_spec.rb
@@ -126,6 +126,8 @@ describe NetSuite::EmployeeFieldsLoader do
     request = NetSuite::Client.new(
       element_secret: "element-secret",
       organization_secret: "org-secret",
+      partner_id: "partnerid",
+      app_id: "appid",
       user_secret: "user-secret",
     ).request
 

--- a/spec/models/net_suite/instance_spec.rb
+++ b/spec/models/net_suite/instance_spec.rb
@@ -10,10 +10,14 @@ describe NetSuite::Instance do
           NetSuite::Authentication,
           email: "test@example.com",
           password: "sekret",
-          account_id: "42"
+          account_id: "42",
+          app_id: "appid",
+          partner_id: "partnerid",
+          company_id: "coid",
+          user_id: "userid",
         )
 
-        instance_hash = NetSuite::Instance.new(authentication).to_h
+        instance_hash = NetSuite::Instance.new(authentication: authentication).to_h
         config = instance_hash["configuration"]
         element = instance_hash["element"]
 
@@ -21,6 +25,11 @@ describe NetSuite::Instance do
         expect(config["user.password"]).to eq authentication.password
         expect(config["netsuite.accountId"]).to eq authentication.account_id
         expect(config["netsuite.sandbox"]).to eq false
+        expect(config["netsuite.appId"]).to eq "appid"
+        expect(config["netsuite.sso.roleId"]).to eq "3"
+        expect(config["netsuite.sso.companyId"]).to eq "coid"
+        expect(config["netsuite.sso.userId"]).to eq "userid"
+        expect(config["netsuite.sso.partnerId"]).to eq "partnerid"
         expect(element["key"]).to eq "netsuiteerp"
         expect(instance_hash["tags"]).to eq []
         expect(instance_hash["name"]).to eq(


### PR DESCRIPTION
In order to authenticate the user properly with NetSuite, we need to set a couple of extra fields, like `roleId`, `appId`.

This PR adds these to the cloud-elements instance creation.

There's a subtle modification on the NEtsuite Credentials page.