### PR TITLE
Increase pageSize on request to employees endpoint on CE.

### DIFF
--- a/app/models/net_suite/client.rb
+++ b/app/models/net_suite/client.rb
@@ -4,6 +4,7 @@ module NetSuite
     EMPLOYEE_REQUEST = REQUEST_BASE + "/employees"
     SUBSIDIARY_REQUEST = REQUEST_BASE + "/lookups/subsidiary"
     INSTANCES = "/instances"
+    PAGE_SIZE = 5000
 
     delegate :get_json, to: :request
     delegate :submit_json, to: :request
@@ -71,7 +72,7 @@ module NetSuite
     def employees
       Rails.logger.debug { "Get employees" }
 
-      get_json(EMPLOYEE_REQUEST)
+      get_json("#{EMPLOYEE_REQUEST}?pageSize=#{PAGE_SIZE}")
     end
 
     def subsidiaries

--- a/spec/features/user_exports_to_net_suite_spec.rb
+++ b/spec/features/user_exports_to_net_suite_spec.rb
@@ -8,11 +8,16 @@ feature "user exports to net suite" do
     employee_json =
       File.read("spec/fixtures/api_responses/net_suite_employee.json")
 
+    stub_request(:get, %r{#{cloud_elements}/employees\?pageSize=5}).
+      to_return(status: 200, body: employee_json)
+
     stub_request(
       :get,
       "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees?pageSize=5000"
     ).to_return(
-      body: [{internalId: "1234", firstName: "TT"}].to_json
+      body: [
+        {internalId: "1234", firstName: "TT"},
+      ].to_json
     )
     stub_namely_data("/profiles", "profiles_with_net_suite_fields")
     stub_request(:put, %r{.*api/v1/profiles/.*}).to_return(status: 200)
@@ -25,8 +30,7 @@ feature "user exports to net suite" do
     stub_request(:post, "#{cloud_elements}/employees").
       with(body: /Mickey/).
       to_return(status: 400, body: { "message" => "Bad Data" }.to_json)
-    stub_request(:get, %r{#{cloud_elements}/employees\?pageSize=.*}).
-      to_return(status: 200, body: employee_json)
+
     stub_namely_fields("fields_with_net_suite")
     stub_request(
       :post,

--- a/spec/features/user_exports_to_net_suite_spec.rb
+++ b/spec/features/user_exports_to_net_suite_spec.rb
@@ -10,7 +10,7 @@ feature "user exports to net suite" do
 
     stub_request(
       :get,
-      "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees"
+      "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees?pageSize=5000"
     ).to_return(
       body: [{internalId: "1234", firstName: "TT"}].to_json
     )

--- a/spec/features/user_retries_failed_profile_sync_spec.rb
+++ b/spec/features/user_retries_failed_profile_sync_spec.rb
@@ -51,7 +51,7 @@ feature "User retries failed profile sync" do
   def stub_netsuite_employees
     stub_request(
       :get,
-      "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees"
+      "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees?pageSize=5000"
     ).to_return(
       body: [{internalId: "1234", firstName: "TT"}].to_json
     )

--- a/spec/models/net_suite/client_spec.rb
+++ b/spec/models/net_suite/client_spec.rb
@@ -270,7 +270,7 @@ describe NetSuite::Client do
       stub_request(
         :get,
         "https://api.cloud-elements.com/elements/api-v2" \
-        "/hubs/erp/employees"
+        "/hubs/erp/employees?pageSize=5000"
       ).
         with(
           headers: {


### PR DESCRIPTION
This is because we're diffing against the employees returned and 200 will cause duplicate failures on NetSuite.