### PR TITLE
Only pull employees from netsuite for the subsidiary that we care about.

### DIFF
--- a/app/models/net_suite/client.rb
+++ b/app/models/net_suite/client.rb
@@ -69,10 +69,15 @@ module NetSuite
       )
     end
 
-    def employees
+    # Retrieves all employees from CE for a specific subsidiary
+    #
+    # @param subsidiary_id [Fixnum] The Subsidiary ID on NetSuite to retrieve for
+    def employees(subsidiary_id)
       Rails.logger.debug("Get employees")
 
-      get_json(EMPLOYEE_REQUEST, paginated: true)
+      get_json(EMPLOYEE_REQUEST, paginated: true, params: {
+        where: { "subsidiary" => subsidiary_id }.to_query
+      })
     end
 
     def subsidiaries

--- a/app/models/net_suite/client/request.rb
+++ b/app/models/net_suite/client/request.rb
@@ -21,9 +21,9 @@ module NetSuite
         end
       end
 
-      def get_json(path, paginated: false)
+      def get_json(path, paginated: false, params: {})
         if paginated
-          get_paginated_json(path)
+          get_paginated_json(path, params.dup)
         else
           translate_response do
             RestClient.get(
@@ -37,9 +37,8 @@ module NetSuite
 
       private
 
-      def get_paginated_json(path)
+      def get_paginated_json(path, params)
         objects = []
-        params = {}
         response = nil
 
         loop do

--- a/app/models/net_suite/export.rb
+++ b/app/models/net_suite/export.rb
@@ -60,7 +60,7 @@ module NetSuite
         mapper: normalizer,
         fields: ["email"],
         profiles: namely_profiles,
-        employees: net_suite_client.employees)
+        employees: net_suite_client.employees(net_suite_connection.subsidiary_id))
     end
 
     def normalize(employee)

--- a/spec/features/user_exports_to_net_suite_spec.rb
+++ b/spec/features/user_exports_to_net_suite_spec.rb
@@ -5,6 +5,8 @@ feature "user exports to net suite" do
     user = create(:user)
     cloud_elements = "https://api.cloud-elements.com/elements/api-v2/hubs/erp"
     subsidiary_url = "#{cloud_elements}/lookups/subsidiary"
+    subsidiary_id = 52
+
     employee_json =
       File.read("spec/fixtures/api_responses/net_suite_employee.json")
 
@@ -13,7 +15,7 @@ feature "user exports to net suite" do
 
     stub_request(
       :get,
-      "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees"
+      "#{cloud_elements}/employees?where=subsidiary%3D#{subsidiary_id}"
     ).to_return(
       body: [
         {internalId: "1234", firstName: "TT"},
@@ -37,7 +39,7 @@ feature "user exports to net suite" do
       "https://api.cloud-elements.com/elements/api-v2/instances"
     ).to_return(status: 200, body: { id: "1", token: "2" }.to_json)
     stub_request(:get, subsidiary_url).
-      to_return(status: 200, body: [{ name: "hello", internalId: 1 }].to_json)
+      to_return(status: 200, body: [{ name: "hello", internalId: subsidiary_id }].to_json)
 
     visit dashboard_path(as: user)
 

--- a/spec/features/user_retries_failed_profile_sync_spec.rb
+++ b/spec/features/user_retries_failed_profile_sync_spec.rb
@@ -6,7 +6,7 @@ feature "User retries failed profile sync" do
     connection = create_connection_for(user)
     create_failed_profile_event_for(connection)
     stub_profile_update
-    stub_netsuite_employees
+    stub_netsuite_employees(connection.subsidiary_id)
     stub_namely_data("/profiles", "profiles_with_net_suite_fields")
     stub_namely_fields("fields_with_net_suite")
     stub_retry_of_failed_profile_event
@@ -48,10 +48,10 @@ feature "User retries failed profile sync" do
     ).with(body: hash_including(firstName: "Tina")).to_return(status: 200)
   end
 
-  def stub_netsuite_employees
+  def stub_netsuite_employees(subsidiary_id)
     stub_request(
       :get,
-      "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees"
+      "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees?where=subsidiary%3D#{subsidiary_id}"
     ).to_return(
       body: [{internalId: "1234", firstName: "TT"}].to_json
     )

--- a/spec/models/net_suite/client_spec.rb
+++ b/spec/models/net_suite/client_spec.rb
@@ -279,12 +279,13 @@ describe NetSuite::Client do
       stub_request(
         :get,
         "https://api.cloud-elements.com/elements/api-v2" \
-        "/hubs/erp/employees"
+        "/hubs/erp/employees" \
+        "?where=subsidiary%3D1"
       ).
         with(headers: expected_headers).
         to_return(status: 200, body: namely_fixture('net_suite_employees'))
 
-      result = client.employees
+      result = client.employees(1)
 
       expect(result.count).to eq(5)
       expect(result).to all(be_kind_of(Hash))
@@ -292,7 +293,7 @@ describe NetSuite::Client do
 
     it "paginates through employees on Cloud Elements" do
       next_page_token = "I_am_a_token_rwar"
-      first_page_request = stub_request(:get, "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees").
+      first_page_request = stub_request(:get, "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees?where=subsidiary%3D1").
         with(headers: expected_headers).
         to_return(
           status: 200,
@@ -301,11 +302,11 @@ describe NetSuite::Client do
             "Elements-Next-Page-Token" => next_page_token,
           })
 
-      second_page_request = stub_request(:get, "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees?nextPage=#{next_page_token}").
+      second_page_request = stub_request(:get, "https://api.cloud-elements.com/elements/api-v2/hubs/erp/employees?nextPage=#{next_page_token}&where=subsidiary%3D1").
         with(headers: expected_headers).
         to_return(status: 200, body: [ internalId: "haioh" ].to_json)
 
-      employees = client.employees
+      employees = client.employees(1)
 
       expect(employees.count).to be(2)
       expect(employees).to all(be_kind_of(Hash))

--- a/spec/models/net_suite/export_spec.rb
+++ b/spec/models/net_suite/export_spec.rb
@@ -239,6 +239,7 @@ describe NetSuite::Export do
 
     double("net_suite_connection", client: client).tap do |connection|
       allow(connection).to receive(:id).and_return(22)
+      allow(connection).to receive(:subsidiary_id).and_return(1)
     end
   end
 


### PR DESCRIPTION
This change makes sure that we only pull the employees for the subsidiary set on the initial connection setup for netsuite. Since companies could have many subsidiaries, this is important to handle.