### PR TITLE
Update jobvite normalizer to include jobvite_id

### DIFF
--- a/app/models/jobvite/normalizer.rb
+++ b/app/models/jobvite/normalizer.rb
@@ -13,7 +13,8 @@ module Jobvite
         user_status: "active",
         start_date: jobvite_candidate.start_date,
         gender: namely_gender(jobvite_candidate.gender),
-        namely_identifier_field => identifier(jobvite_candidate),
+      ).merge(
+        namely_identifier_field => identifier(jobvite_candidate)
       )
     end
 

--- a/spec/models/jobvite/normalizer_spec.rb
+++ b/spec/models/jobvite/normalizer_spec.rb
@@ -25,7 +25,6 @@ describe Jobvite::Normalizer do
           personal_email: "crash.override@example.com",
           user_status: "active",
           start_date: "2014-01-02",
-          jobvite_id: "edO1Ggwt",
           gender: nil,
         )
     end
@@ -77,6 +76,24 @@ describe Jobvite::Normalizer do
       expect(attribute_mapper).
         to have_imported(hash_including(start_date: nil))
     end
+
+    it "returns a hash including the Jobvite identifier" do
+      attribute_mapper = build(:attribute_mapper)
+      mapper = described_class.new(attribute_mapper: attribute_mapper)
+      jobvite_candidate = double(
+        "jobvite_candidate",
+        e_id: "edO1Ggwt",
+        email: "crash.override@example.com",
+        first_name: "Dade",
+        last_name: "Murphy",
+        start_date: "2014-01-02",
+        gender: "Undefined",
+      )
+
+      hash = mapper.call(jobvite_candidate)
+
+      expect(hash[mapper.namely_identifier_field]).to eq(jobvite_candidate.e_id)
+    end
   end
 
   describe "#namely_identifier_field" do
@@ -116,7 +133,7 @@ describe Jobvite::Normalizer do
 
   def stub_attribute_mapper
     double(:attribute_mapper).tap do |attribute_mapper|
-      allow(attribute_mapper).to receive(:import)
+      allow(attribute_mapper).to receive(:import).and_return({})
     end
   end
 


### PR DESCRIPTION
This fixes a problem where the normalizer would never actually output the jobvite_id. Because we stub everything, we stubbed the wrong thing and didn't catch this. But the truth is that the attribute mapper never actually maps the jobvite_id, so it would never be exported. This just merges in the jobvite_id attribute.

/cc @macat 