### PR TITLE
Add hireDate as a standard field for netsuite.

### DIFF
--- a/app/models/fields/date_value.rb
+++ b/app/models/fields/date_value.rb
@@ -1,7 +1,7 @@
 module Fields
   # Converts date values from Namely.
   class DateValue
-    DATE_FORMAT = "%m/%d/%Y"
+    DATE_FORMAT = "%Y-%m-%d"
 
     def initialize(value)
       @value = value

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -136,6 +136,7 @@ class NetSuite::Connection < ActiveRecord::Base
     mappings.map! "officePhone", to: "office_phone", name: "Office phone"
     mappings.map! "phone", to: "home_phone", name: "Phone"
     mappings.map! "title", to: "job_title", name: "Title"
+    mappings.map! "hireDate", to: "start_date", name: "Hire Date"
 
     mappings.map!(
       "releaseDate",

--- a/app/models/net_suite/normalizer.rb
+++ b/app/models/net_suite/normalizer.rb
@@ -40,6 +40,7 @@ class NetSuite::Normalizer
         "isInactive" => user_status,
         "subsidiary" => subsidiary,
         "releaseDate" => release_date,
+        "hireDate" => hire_date,
       }
     end
 
@@ -73,6 +74,14 @@ class NetSuite::Normalizer
 
       if date.present?
         date.to_datetime.to_i * 1.second.in_milliseconds
+      end
+    end
+
+    def hire_date
+      date = @attributes.fetch("hireDate", Fields::NullValue.new).to_date
+
+      if date.present?
+        date.to_datetime.iso8601
       end
     end
 

--- a/config/initializers/namely_client.rb
+++ b/config/initializers/namely_client.rb
@@ -1,0 +1,20 @@
+Namely::ResourceGateway # Poke the constant to make sure we're not defining from scratch
+
+module Namely
+  class ResourceGateway
+    def json_index_paged
+      Enumerator.new do |y|
+        params = { profile_format: 'full' }
+
+        loop do
+          objects = get("/#{endpoint}", params)[resource_name]
+          break if objects.empty?
+
+          objects.each { |o| y << o }
+
+          params[:after] = objects.last["id"]
+        end
+      end
+    end
+  end
+end

--- a/spec/features/user_imports_jobvite_candidates_spec.rb
+++ b/spec/features/user_imports_jobvite_candidates_spec.rb
@@ -8,7 +8,7 @@ feature "User imports jobvite candidates" do
 
   before do
     stub_request(:get, "#{ api_host }/api/v1/profiles")
-      .with(query: {access_token: ENV['TEST_NAMELY_ACCESS_TOKEN']})
+      .with(query: {access_token: ENV['TEST_NAMELY_ACCESS_TOKEN'], profile_format: "full"})
       .to_return(status: 200, body: File.read("spec/fixtures/api_responses/empty_profiles.json"))
   end
 

--- a/spec/models/fields/collection_spec.rb
+++ b/spec/models/fields/collection_spec.rb
@@ -27,7 +27,7 @@ describe Fields::Collection do
 
     describe "for a date value" do
       it "parses into a date object" do
-        result = export(type: "date", value: "08/26/1986")
+        result = export(type: "date", value: "1986-08-26")
 
         expect(result.to_date).to eq(Date.new(1986, 8, 26))
       end

--- a/spec/models/fields/date_value_spec.rb
+++ b/spec/models/fields/date_value_spec.rb
@@ -15,7 +15,7 @@ describe Fields::DateValue do
 
   describe "#to_date" do
     it "parses a Namely date string" do
-      expect(Fields::DateValue.new("08/26/1986").to_date).
+      expect(Fields::DateValue.new("1986-08-26").to_date).
         to eq(Date.new(1986, 8, 26))
     end
 

--- a/spec/models/net_suite/connection_spec.rb
+++ b/spec/models/net_suite/connection_spec.rb
@@ -159,6 +159,7 @@ describe NetSuite::Connection do
         %w(mobilePhone mobile_phone),
         %w(officePhone office_phone),
         %w(phone home_phone),
+        %w(hireDate start_date),
         %w(releaseDate departure_date),
         %w(title job_title),
         %w(address home),

--- a/spec/models/net_suite/normalizer_spec.rb
+++ b/spec/models/net_suite/normalizer_spec.rb
@@ -181,7 +181,7 @@ describe NetSuite::Normalizer do
     context "releaseDate" do
       it "maps departure date string to milliseconds since epoch" do
         date = Date.today
-        date_string = date.strftime("%m/%d/%Y")
+        date_string = date.iso8601
         profile_data = stubbed_profile_data.merge(
           "departure_date" => Fields::DateValue.new(date_string)
         )
@@ -236,14 +236,16 @@ describe NetSuite::Normalizer do
     context "null scalar fields" do
       it "moves keys with null scalar values to the nullFieldList" do
         profile_data = stubbed_profile_data.merge(
-          "departure_date" => Fields::DateValue.new(nil)
+          "departure_date" => Fields::DateValue.new(nil),
+          "hire_date" => Fields::DateValue.new(nil),
         )
 
         export_attributes = export(profile_data)
 
-        expect(export_attributes.keys).not_to include("releaseDate")
+        expect(export_attributes.keys).not_to include("releaseDate", "hireDate")
         expect(export_attributes["nullFieldList"]).to match_array([
-          "releaseDate"
+          "releaseDate",
+          "hireDate",
         ])
       end
     end
@@ -277,7 +279,7 @@ describe NetSuite::Normalizer do
         "home_phone" => "212-555-1212",
         "last_name" => "Last",
       }.merge(overrides)
-    ).merge("departure_date" => Fields::DateValue.new("01/01/2016"))
+    ).merge("departure_date" => Fields::DateValue.new("2016-01-01"))
   end
 
   def stub_string_values(values)


### PR DESCRIPTION
We didn't have `hireDate` as a standard Netsuite field in our attribute mapper. This PR adds it as a standard field.

This PR also boyscouts a lot of issues with the Namely API changing under our feet, for example:

* Date formats changing causing date parsing to fail
* Profile JSON being shorted. (Fixed with a monkey patch)
