### PR TITLE
Respond 200 to greenhouse secret keys we don't know about.

### DIFF
--- a/spec/controllers/greenhouse_candidate_imports_controler_spec.rb
+++ b/spec/controllers/greenhouse_candidate_imports_controler_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe GreenhouseCandidateImportsController, type: :controller do
+  describe 'POST #create' do
+    context 'when the secret key does not exist' do
+      it 'returns a 200' do
+        post :create, secret_key: "bunk"
+
+        expect(response.status).to be(200)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is because clients remove the connection from Namely Connect for greenhouse but don't disable the webhook from their Greenhouse account. So we still get webhooks dispatched to us. If we don't respond with an OK status message they'll keep dispatching to us as a retry forever. This mitigates our error capturing getting blown up.