### PR TITLE
CORE-130: Netsuite - Add proper support email for authentication error

### DIFF
--- a/app/models/net_suite/authentication.rb
+++ b/app/models/net_suite/authentication.rb
@@ -50,8 +50,12 @@ module NetSuite
       )
       true
     rescue NetSuite::ApiError => exception
-      errors.add(:base, exception.message)
+      errors.add(:base, add_proper_support_email(exception.message))
       false
+    end
+
+    def add_proper_support_email(message)
+      message.gsub(/.+@.+\.\w{3}/, ENV.fetch("SUPPORT_EMAIL", "api@namely.com"))
     end
 
     def attributes

--- a/spec/features/user_connects_net_suite_account_spec.rb
+++ b/spec/features/user_connects_net_suite_account_spec.rb
@@ -27,14 +27,14 @@ feature "user connects NetSuite account" do
   end
 
   scenario "with bad authentication" do
-    stub_create_instance(status: 400, body: { message: "Not good" })
+    stub_create_instance(status: 400, body: { message: "The registering of the partner failed. Please contact support@cloud-elements.com to get setup as a partner." })
 
     visit_dashboard
 
     net_suite.click_link t("dashboards.show.connect")
 
     submit_net_suite_account_form
-    expect(page).to have_content("Not good")
+    expect(page).to have_content("api@namely.com")
   end
 
   scenario "with updated credentials" do


### PR DESCRIPTION
The user shouldn't be able to see the cloud elements support email when there's an issue with them.