### PR TITLE
CORE-114: Disable supervisor mapping in ui

### DIFF
--- a/app/models/namely_fields_by_label.rb
+++ b/app/models/namely_fields_by_label.rb
@@ -1,0 +1,26 @@
+class NamelyFieldsByLabel
+  DISABLE_FIELDS = [
+    ["Supervisor NetSuite Id", "netsuite_supervisor_id"]
+  ]
+  def initialize(namely_fields:)
+    @namely_fields = namely_fields
+  end
+
+  def to_a
+    namely_fields + DISABLE_FIELDS
+  end
+
+  def is_disable_field?(namely_field_name)
+    DISABLE_FIELDS.map do |disable_field|
+      disable_field.last
+    end.include?(namely_field_name)
+  end
+
+  def disable_namely_fields
+    namely_fields.map { |namely_field_tuple| namely_field_tuple.last }
+  end
+
+  private
+
+  attr_reader :namely_fields
+end

--- a/app/models/net_suite/connection.rb
+++ b/app/models/net_suite/connection.rb
@@ -139,6 +139,7 @@ class NetSuite::Connection < ActiveRecord::Base
     mappings.map! "phone", to: "home_phone", name: "Phone"
     mappings.map! "title", to: "job_title", name: "Title"
     mappings.map! "hireDate", to: "start_date", name: "Hire Date"
+    mappings.map! "supervisor", to: "netsuite_supervisor_id", name: "Supervisor"
 
     mappings.map!(
       "releaseDate",

--- a/app/models/net_suite/normalizer.rb
+++ b/app/models/net_suite/normalizer.rb
@@ -41,6 +41,7 @@ class NetSuite::Normalizer
         "subsidiary" => subsidiary,
         "releaseDate" => release_date,
         "hireDate" => hire_date,
+        "supervisor" => supervisor,
       }
     end
 
@@ -87,6 +88,12 @@ class NetSuite::Normalizer
 
     def subsidiary
       { "internalId" => @subsidiary_id }
+    end
+
+    def supervisor
+      {
+        "internalId" => @attributes.fetch("supervisor", Fields::NullValue.new).to_s
+      }
     end
 
     def custom_keys(attributes)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,11 +16,13 @@ class User < ActiveRecord::Base
   end
 
   def namely_fields_by_label
-    namely_fields.
+    NamelyFieldsByLabel.new(
+      namely_fields: namely_fields.
       all.
       select { |field| AttributeMapper::SUPPORTED_TYPES.include?(field.type) }.
       sort_by { |field| field.label.downcase }.
       map { |field| [field.label, field.name] }
+    )
   end
 
   def namely_fields
@@ -43,4 +45,5 @@ class User < ActiveRecord::Base
     self.access_token_expiry = Users::TokenExpiry.for(access_token_expires_in)
     save
   end
+
 end

--- a/app/views/mappings/_field_mapping.html.erb
+++ b/app/views/mappings/_field_mapping.html.erb
@@ -9,10 +9,19 @@
     ) %>
   </td>
   <td>
-    <%= fields.input(
-      :namely_field_name,
-      collection: namely_fields,
-      label: false
-    ) %>
+    <% if namely_fields.is_disable_field?(field_mapping.namely_field_name) %>
+      <%= fields.input(
+        :namely_field_name,
+        collection: namely_fields,
+        disabled: namely_fields.disable_namely_fields,
+        label: false
+      ) %>
+  <% else %>
+      <%= fields.input(
+        :namely_field_name,
+        collection: namely_fields,
+        label: false
+      ) %>
+  <% end %>
   </td>
 </tr>

--- a/spec/features/user_views_netsuite_supervisor_field_mapping_spec.rb
+++ b/spec/features/user_views_netsuite_supervisor_field_mapping_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+feature "User view supervisor netsuite field mapping" do
+  scenario "successfully" do
+    user = create(:user)
+    cloud_elements = "https://api.cloud-elements.com/elements/api-v2/hubs/erp"
+    subsidiary_url = "#{cloud_elements}/lookups/subsidiary"
+    subsidiary_id = 52
+
+    employee_json =
+      File.read("spec/fixtures/api_responses/net_suite_employee.json")
+
+    stub_request(:get, %r{#{cloud_elements}/employees\?pageSize=5}).
+      to_return(status: 200, body: employee_json)
+
+    stub_request(
+      :get,
+      "#{cloud_elements}/employees?where=subsidiary%3D#{subsidiary_id}"
+    ).to_return(
+      body: [
+        {internalId: "1234", firstName: "TT"},
+      ].to_json
+    )
+    stub_namely_data("/profiles", "profiles_with_net_suite_fields")
+    stub_request(:put, %r{.*api/v1/profiles/.*}).to_return(status: 200)
+    stub_request(:post, "#{cloud_elements}/employees").
+      with(body: /Sally/).
+      to_return(status: 200, body: { "internalId" => "123" }.to_json)
+    stub_request(:patch, "#{cloud_elements}/employees/1234").
+      with(body: /Tina/).
+      to_return(status: 200, body: { "internalId" => "1234" }.to_json)
+    stub_request(:post, "#{cloud_elements}/employees").
+      with(body: /Mickey/).
+      to_return(status: 400, body: { "message" => "Bad Data" }.to_json)
+
+    stub_namely_fields("fields_with_net_suite")
+    stub_request(
+      :post,
+      "https://api.cloud-elements.com/elements/api-v2/instances"
+    ).to_return(status: 200, body: { id: "1", token: "2" }.to_json)
+    stub_request(:get, subsidiary_url).
+      to_return(status: 200, body: [{ name: "hello", internalId: subsidiary_id }].to_json)
+
+    visit dashboard_path(as: user)
+
+    find(".net-suite-account").click_on t("dashboards.show.connect")
+
+    fill_in("net_suite_authentication_account_id", with: "123xy")
+    fill_in("net_suite_authentication_email", with: user.email)
+    fill_in("net_suite_authentication_password", with: "abc12z")
+    click_button t("helpers.submit.net_suite_connection.update")
+
+    select("hello", from: "net_suite_connection_subsidiary_id")
+    click_button t("helpers.submit.net_suite_connection.update")
+
+    expect(page).to have_select("Supervisor", selected: "Supervisor NetSuite Id")
+    select("Home", from: "Supervisor")
+    expect(page).not_to have_select("Supervisor", selected: "Home")
+  end
+
+  def click_netsuite_mappings_link
+    within(".net-suite-account") do
+      click_link t("dashboards.show.edit_mappings")
+    end
+  end
+end

--- a/spec/models/namely_fields_by_label_spec.rb
+++ b/spec/models/namely_fields_by_label_spec.rb
@@ -1,0 +1,40 @@
+require_relative "../../app/models/namely_fields_by_label"
+
+describe NamelyFieldsByLabel do
+  subject(:namely_fields_by_label) do
+    described_class.new(namely_fields: namely_fields)
+  end
+  let(:namely_fields) { [["First Name", "first_name"]] }
+
+  describe "#to_a" do
+    it "appends netsuite supervisor id to the standard fields from Namely" do
+      expect(namely_fields_by_label.to_a).to eql [
+        ["First Name", "first_name"],
+        ["Supervisor NetSuite Id", "netsuite_supervisor_id"]
+      ]
+    end
+  end
+
+  describe "#disable_namely_fields" do
+    it "returns the names of all namely fields" do
+      expect(
+        namely_fields_by_label.disable_namely_fields
+      ).to eql ["first_name"]
+    end
+  end
+
+  describe "#is_disable_field?" do
+    let(:field_to_disable) { "netsuite_supervisor_id" }
+    context "when the field name is marked for be disabled" do
+      it "returns true" do
+        expect(namely_fields_by_label).to be_is_disable_field(field_to_disable)
+      end
+    end
+
+    context "when the field name is not marked for be disabled" do
+      it "returns false" do
+        expect(namely_fields_by_label).not_to be_is_disable_field("non_field")
+      end
+    end
+  end
+end

--- a/spec/models/net_suite/connection_spec.rb
+++ b/spec/models/net_suite/connection_spec.rb
@@ -163,6 +163,7 @@ describe NetSuite::Connection do
         %w(releaseDate departure_date),
         %w(title job_title),
         %w(address home),
+        %w(supervisor netsuite_supervisor_id),
         ["initials", nil],
       ])
     end

--- a/spec/models/net_suite/normalizer_spec.rb
+++ b/spec/models/net_suite/normalizer_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 describe NetSuite::Normalizer do
-  let(:configuration) { double("configuration", subsidiary_id: "123") }
+  let(:configuration) do
+    double( "configuration", subsidiary_id: "123")
+  end
 
   describe "delegation" do
     subject { build_normalizer }
@@ -13,7 +15,8 @@ describe NetSuite::Normalizer do
     it "returns a converted data structure based on field mappings" do
       export_attributes = export
 
-      expect(export_attributes.keys).to match_array(%w(
+      expect(export_attributes.keys).to match_array(
+        %w(
         customFieldList
         email
         firstName
@@ -24,7 +27,9 @@ describe NetSuite::Normalizer do
         subsidiary
         releaseDate
         nullFieldList
-      ))
+        supervisor
+        )
+      )
     end
 
     it "does not include custom fields in field mappings if opted out" do
@@ -175,6 +180,25 @@ describe NetSuite::Normalizer do
         expect(
           export_attributes["subsidiary"]
         ).to eq("internalId" => configuration.subsidiary_id)
+      end
+    end
+
+    context "supervisor" do
+      it "provides a supervisor from attributes on the profile" do
+        profile_data = stubbed_profile_data({"netsuite_supervisor_id" => "456"})
+        export_attributes = export(profile_data)
+
+        expect(
+          export_attributes["supervisor"]
+        ).to eq("internalId" => "456")
+      end
+
+      it "returns a blank without a netsuite_id" do
+        export_attributes = export
+
+        expect(
+          export_attributes["supervisor"]
+        ).to eq("internalId" => nil)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,45 +54,6 @@ describe User do
     end
   end
 
-  describe "#namely_fields_by_label" do
-    it "returns mappable fields from a Namely connection alphabetically" do
-      models = [
-        double(name: "first_name", label: "First name", type: "text"),
-        double(name: "last_name", label: "Last name", type: "longtext"),
-        double(name: "gender", label: "Gender", type: "select"),
-        double(name: "email", label: "Email", type: "email"),
-        double(name: "job_title", label: "Job title", type: "referencehistory"),
-        double(name: "user_status", label: "Status", type: "referenceselect"),
-        double(name: "start_date", label: "started", type: "date"),
-        double(name: "home", label: "Home address", type: "address"),
-        stub_profile_field(type: "checkboxes"),
-        stub_profile_field(type: "file"),
-        stub_profile_field(type: "image"),
-        stub_profile_field(type: "salary"),
-      ]
-      fields = double("fields", all: models)
-      stub_namely_connection fields: fields
-      user = User.new
-
-      result = user.namely_fields_by_label
-
-      expect(result).to eq([
-        ["Email", "email"],
-        ["First name", "first_name"],
-        ["Gender", "gender"],
-        ["Home address", "home"],
-        ["Job title", "job_title"],
-        ["Last name", "last_name"],
-        ["started", "start_date"],
-        ["Status", "user_status"],
-      ])
-    end
-
-    def stub_profile_field(type:)
-      double(name: type, label: "#{type} field", type: type)
-    end
-  end
-
   describe "#namely_fields" do
     it "returns fields from its Namely connection" do
       fields = double(:namely_fields)


### PR DESCRIPTION
- Add initial code for assigning a supervisor to the imported profile
- Add supervisor field to get mapped on import Using internalId as the supervisor field
- Refactor the code related to supervisor to use a new field generated by the ProfileSorter
- Fix failing spec after adding new mapping for NetSuite::Connection
- Rename supervisor_netsuite_id to netsuite_supervisor_id
- Add NamelyFieldsByLabel decorator class to add the supervisor netsuite id field
- Add NamelyFieldsByLabel#disable_namely_fields to disable every other field so the user can't not map it
- Add implementation for #disable_namely_fields
- Add assertion to check for the Supervisor dropdown in the mapping for Netsuite
- Remove expectation for User#namely_fields_by_label the logic is abstracted in NamelyFieldsByLabel
- Add initial code for assigning a supervisor to the imported profile
- Add supervisor field to get mapped on import
- Using internalId as the supervisor field
- Add NamelyFieldsByLabel decorator class to add the supervisor netsuite id field
- Add NamelyFieldsByLabel#disable_namely_fields to disable every other field so the user can't not map it
- Remove the disabling of the supervisor id, need to think in a better way to implement this right now disabling one field in the drop down disables all the others
- Add proper assertion to disabling drop down for supervisor netsuite id
- Add #is_disable_field? to check if the current namely field is marked for disabling