### PR TITLE
Bubble up NetSuite::Api errors.

### DIFF
--- a/app/models/net_suite/client/request.rb
+++ b/app/models/net_suite/client/request.rb
@@ -99,6 +99,7 @@ module NetSuite
         case exception.response.body
         when /already an employee with external access/
           Rails.logger.info("netsuite error: external employee error")
+          raise NetSuite::ApiError, exception, exception.backtrace
         else
           track_and_log_exception(exception)
         end

--- a/spec/models/net_suite/client_spec.rb
+++ b/spec/models/net_suite/client_spec.rb
@@ -204,7 +204,7 @@ describe NetSuite::Client do
           element_secret: "element-secret"
         )
 
-        expect { client.create_employee({}) }.to_not raise_error
+        expect { client.create_employee({}) }.to raise_error(NetSuite::ApiError)
       end
     end
   end


### PR DESCRIPTION
This is so that profile event summaries don't blow up and are tracked correctly.